### PR TITLE
fix: disable metro cache

### DIFF
--- a/packages/uniwind/src/metro/index.d.ts
+++ b/packages/uniwind/src/metro/index.d.ts
@@ -11,4 +11,4 @@ type UniwindConfig = {
     polyfills?: Polyfills
 }
 
-export declare function withUniwindConfig(config: MetroConfig, options: UniwindConfig): () => Promise<MetroConfig>
+export declare function withUniwindConfig(config: MetroConfig, options: UniwindConfig): MetroConfig

--- a/packages/uniwind/src/metro/metro-transformer.ts
+++ b/packages/uniwind/src/metro/metro-transformer.ts
@@ -1,13 +1,12 @@
 import { Scanner } from '@tailwindcss/oxide'
 import fs from 'fs'
-import type { JsTransformerConfig, JsTransformOptions, TransformResponse } from 'metro-transform-worker'
+import type { JsTransformerConfig, JsTransformOptions } from 'metro-transform-worker'
 import path from 'path'
 import { name } from '../../package.json'
 import { compileVirtual } from './compileVirtual'
 import { getSources } from './getSources'
 import { injectThemes } from './injectThemes'
 import { Platform, UniwindConfig } from './types'
-import { areSetsEqual } from './utils'
 
 let worker: typeof import('metro-transform-worker')
 
@@ -15,12 +14,6 @@ try {
     worker = require('@expo/metro-config/build/transform-worker/transform-worker.js')
 } catch {
     worker = require('metro-transform-worker')
-}
-
-const uniwindCache = {
-    css: '',
-    candidates: new Set<string>(),
-    cachedTransforms: new Map<Platform, TransformResponse>(),
 }
 
 export const transform = async (
@@ -58,17 +51,7 @@ export const transform = async (
     const css = fs.readFileSync(filePath, 'utf-8')
     const sources = getSources(css, path.dirname(cssPath))
     const platform = options.platform as Platform
-    const cached = uniwindCache.cachedTransforms.get(platform)
     const candidates = new Scanner({ sources }).scan()
-    const candidatesSet = new Set(candidates)
-
-    if (cached && uniwindCache.css === css && areSetsEqual(uniwindCache.candidates, candidatesSet)) {
-        return cached
-    }
-
-    uniwindCache.css = css
-    uniwindCache.candidates = candidatesSet
-
     const virtualCode = await compileVirtual({
         css,
         platform,
@@ -97,8 +80,6 @@ export const transform = async (
         data,
         options,
     )
-
-    uniwindCache.cachedTransforms.set(platform, transform)
 
     transform.output[0].data.css ??= {}
     transform.output[0].data.css.skipCache = true

--- a/packages/uniwind/src/metro/utils/common.ts
+++ b/packages/uniwind/src/metro/utils/common.ts
@@ -44,20 +44,6 @@ export const percentageToFloat = (value: string) => {
     return Number(value.replace('%', '')) / 100
 }
 
-export const areSetsEqual = <T>(a: Set<T>, b: Set<T>) => {
-    if (a.size !== b.size) {
-        return false
-    }
-
-    for (const item of a) {
-        if (!b.has(item)) {
-            return false
-        }
-    }
-
-    return true
-}
-
 export const addMissingSpaces = (str: string) =>
     pipe(str)(
         x => x.trim(),


### PR DESCRIPTION
Cache in custom metro transformer caused some unpredictable behaviors when running multiple devices at once