### PR TITLE
chore: fix banner image in package README

### DIFF
--- a/packages/uniwind/readme.md
+++ b/packages/uniwind/readme.md
@@ -1,6 +1,5 @@
-[<img alt="uniwind" src="assets/banner.png">](https://uniwind.dev/)
-
 <div align="center">
+    <a href="https://uniwind.dev/"><img alt="uniwind" src="../../assets/banner.png"></a>
     <p align="center">
         <a href="https://uniwind.dev/" target="_blank">
             <h1 align="center" style="color:red;">Uniwind</h1>


### PR DESCRIPTION
# Why

While working on React Native Directory feature I have spotted that after switch to monorepo structure, the banner in `uniwind` package README is rendered as a broken image.

# How

Correct the `img` asset path, move the `img` inside centered block so it matches the header, instead being shifted to the left side.

# Preview

https://github.com/Simek/uniwind/tree/patch-1/packages/uniwind#readme
