### PR TITLE
feat: support text-shadow

### DIFF
--- a/packages/uniwind/src/core/native/parsers/index.ts
+++ b/packages/uniwind/src/core/native/parsers/index.ts
@@ -1,4 +1,5 @@
 export * from './boxShadow'
 export * from './fontVariant'
 export * from './gradient'
+export * from './textShadow'
 export * from './transforms'

--- a/packages/uniwind/src/core/native/parsers/textShadow.ts
+++ b/packages/uniwind/src/core/native/parsers/textShadow.ts
@@ -1,0 +1,37 @@
+export const parseTextShadowMutation = (styles: Record<string, any>) => {
+    const tokens: Array<string> = styles.textShadow.replace(/,/g, '').split(' ')
+
+    if (tokens.length === 0) {
+        return
+    }
+
+    const color = tokens.find(token => token.startsWith('#')) ?? '#000000'
+    const offsets = tokens.filter(token => token !== color)
+    const [offsetX, offsetY, radius] = offsets
+
+    if (offsetX !== undefined && offsetY !== undefined) {
+        Object.defineProperty(styles, 'textShadowOffset', {
+            configurable: true,
+            enumerable: true,
+            value: {
+                width: Number(offsetX),
+                height: Number(offsetY),
+            },
+        })
+        delete styles.textShadow
+    }
+
+    if (radius !== undefined) {
+        Object.defineProperty(styles, 'textShadowRadius', {
+            configurable: true,
+            enumerable: true,
+            value: Number(radius),
+        })
+    }
+
+    Object.defineProperty(styles, 'textShadowColor', {
+        configurable: true,
+        enumerable: true,
+        value: color,
+    })
+}

--- a/packages/uniwind/src/core/native/store.ts
+++ b/packages/uniwind/src/core/native/store.ts
@@ -5,7 +5,7 @@ import { Uniwind } from '../config/config'
 import { UniwindListener } from '../listener'
 import { ComponentState, GenerateStyleSheetsCallback, RNStyle, Style, StyleSheets } from '../types'
 import { cloneWithAccessors } from './native-utils'
-import { parseBoxShadow, parseFontVariant, parseTransformsMutation, resolveGradient } from './parsers'
+import { parseBoxShadow, parseFontVariant, parseTextShadowMutation, parseTransformsMutation, resolveGradient } from './parsers'
 import { UniwindRuntime } from './runtime'
 
 type StylesResult = {
@@ -212,6 +212,10 @@ class UniwindStoreBuilder {
                 configurable: true,
                 enumerable: true,
             })
+        }
+
+        if (result.textShadow !== undefined) {
+            parseTextShadowMutation(result)
         }
 
         return {


### PR DESCRIPTION
<img width="1320" height="2868" alt="simulator_screenshot_4DF78039-61A2-48E8-A945-F1A92CA6B746" src="https://github.com/user-attachments/assets/fc6cfcb2-e6fa-4967-8e90-353dfc13acaa" />

React Native supports only single text-shadow unlike web, there's no workaround that so text-shadow on native will look different in some cases than on the web