### PR TITLE
perf(native): optimize useStyle used in native components

### DIFF
--- a/packages/uniwind/src/components/native/useStyle.ts
+++ b/packages/uniwind/src/components/native/useStyle.ts
@@ -10,8 +10,15 @@ const emptyState = { styles: {} as RNStyle, dependencies: [] as Array<StyleDepen
 export const useStyle = (className?: string, state?: ComponentState) => {
     const [_, rerender] = useReducer(() => ({}), {})
     const styleState = useMemo(
-        () => className ? UniwindStore.getStyles(className, state) : emptyState,
-        [className, _, state],
+        () =>
+            className
+                ? UniwindStore.getStyles(className, {
+                    isDisabled: state?.isDisabled,
+                    isFocused: state?.isFocused,
+                    isPressed: state?.isPressed,
+                })
+                : emptyState,
+        [className, _, state?.isDisabled, state?.isFocused, state?.isPressed],
     )
 
     useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes react compiler's auto-memoization in the useSyle hook used to style native components. The React Compiler automatically memoizes components and their dependencies, but it needs the code to follow certain patterns.