### PR TITLE
feat: add updateInsets public function to uniwind

### DIFF
--- a/packages/uniwind/src/core/config/config.common.ts
+++ b/packages/uniwind/src/core/config/config.common.ts
@@ -1,4 +1,4 @@
-import { Appearance, Platform } from 'react-native'
+import { Appearance, Insets, Platform } from 'react-native'
 import { ColorScheme, StyleDependency, UniwindConfig } from '../../types'
 import { UniwindListener } from '../listener'
 import { CSSVariables, GenerateStyleSheetsCallback } from '../types'
@@ -84,6 +84,11 @@ export class UniwindConfigBuilder {
         // noop
         theme
         variables
+    }
+
+    updateInsets(insets: Insets) {
+        // noop
+        insets
     }
 
     protected __reinit(_: GenerateStyleSheetsCallback, themes: Array<string>) {

--- a/packages/uniwind/src/core/config/config.native.ts
+++ b/packages/uniwind/src/core/config/config.native.ts
@@ -1,4 +1,5 @@
 import { formatHex, formatHex8, parse } from 'culori'
+import { Insets } from 'react-native'
 import { StyleDependency } from '../../types'
 import { UniwindListener } from '../listener'
 import { Logger } from '../logger'
@@ -64,6 +65,14 @@ class UniwindConfigBuilder extends UniwindConfigBuilderBase {
         if (theme === this.currentTheme) {
             UniwindListener.notify([StyleDependency.Variables])
         }
+    }
+
+    updateInsets(insets: Insets) {
+        UniwindStore.runtime.insets.bottom = insets.bottom ?? 0
+        UniwindStore.runtime.insets.top = insets.top ?? 0
+        UniwindStore.runtime.insets.left = insets.left ?? 0
+        UniwindStore.runtime.insets.right = insets.right ?? 0
+        UniwindListener.notify([StyleDependency.Insets])
     }
 }
 


### PR DESCRIPTION
## Summary

Introduces an `updateInsets` method to both common and native UniwindConfigBuilder classes. The native implementation updates runtime insets and notifies listeners, while the common version is a no-op. This prepares the config for dynamic inset management.

## Impact

This is to add support for class names using the `*-safe`. The root layout for a react native app is wrapped with `SafeAreaListener` from `react-native-safe-area-context` and called in the `onChange` prop:

```tsx
<SafeAreaListener
      onChange={({ insets }) => {
        Uniwind.updateInsets(insets);
      }}
    >
    ...
 </SafeAreaListener>
```