### PR TITLE
fix: process baseline-position

### DIFF
--- a/packages/uniwind/src/metro/processor/css.ts
+++ b/packages/uniwind/src/metro/processor/css.ts
@@ -280,6 +280,8 @@ export class CSS {
                 case 'content-distribution':
                 case 'content-position':
                     return declarationValue.value
+                case 'baseline-position':
+                    return 'baseline'
                 default:
                     // CSS string properties like absolute, relative, italic, etc.
                     if (Object.keys(declarationValue).length === 1) {


### PR DESCRIPTION
React Native [supports](https://reactnative.dev/docs/flexbox#align-self) `baseline` for `alignItems` and `alignSelf` but **lightningcss** process `baseline` as a [baseline-position](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/baseline-position), which gets `first` as a value.

Overriding `baseline-position` with `baseline` seems to work.
