### PR TITLE
feat: add support for extraComponents in metro

### DIFF
--- a/packages/uniwind/src/metro/resolvers.ts
+++ b/packages/uniwind/src/metro/resolvers.ts
@@ -39,7 +39,8 @@ const SUPPORTED_COMPONENTS = [
     'VirtualizedList',
 ]
 
-export const nativeResolver = ({
+export const nativeResolver = (extraComponents: Record<string, string>) =>
+({
     context,
     moduleName,
     platform,
@@ -70,10 +71,16 @@ export const nativeResolver = ({
         }
     }
 
+    if (moduleName in extraComponents) {
+        const componentPath = extraComponents[moduleName]!
+        return resolver(context, componentPath, platform)
+    }
+
     return resolution
 }
 
-export const webResolver = ({
+export const webResolver = (extraComponents: Record<string, string>) =>
+({
     context,
     moduleName,
     platform,
@@ -87,6 +94,11 @@ export const webResolver = ({
         || !resolution.filePath.includes(`${sep}react-native-web${sep}`)
     ) {
         return resolution
+    }
+
+    if (moduleName in extraComponents) {
+        const componentPath = extraComponents[moduleName]!
+        return resolver(context, componentPath, platform)
     }
 
     const segments = resolution.filePath.split(sep)

--- a/packages/uniwind/src/metro/types.ts
+++ b/packages/uniwind/src/metro/types.ts
@@ -21,6 +21,7 @@ export type UniwindConfig = {
     cssEntryFile: string
     themes: Array<string>
     extraThemes?: Array<string>
+    extraComponents?: Record<string, string>
     dtsFile?: string
     polyfills?: Polyfills
     debug?: boolean

--- a/packages/uniwind/src/metro/withUniwindConfig.ts
+++ b/packages/uniwind/src/metro/withUniwindConfig.ts
@@ -45,7 +45,7 @@ export const withUniwindConfig = <T extends MetroConfig>(
             ),
             resolveRequest: (context, moduleName, platform) => {
                 const resolver = config.resolver?.resolveRequest ?? context.resolveRequest
-                const platformResolver = platform === Platform.Web ? webResolver : nativeResolver
+                const platformResolver = (platform === Platform.Web ? webResolver : nativeResolver)(uniwindConfig.extraComponents ?? {})
                 const resolved = platformResolver({
                     context,
                     moduleName,


### PR DESCRIPTION
## Summary

Introduces an extraComponents option to UniwindConfig and updates the native and web Metro resolvers to allow custom component resolution. This enables users to specify additional component mappings for module resolution at metro level.