### PR TITLE
fix: Include LICENSE file in the published package

### DIFF
--- a/packages/uniwind/.gitignore
+++ b/packages/uniwind/.gitignore
@@ -1,0 +1,1 @@
+LICENSE

--- a/packages/uniwind/build.config.ts
+++ b/packages/uniwind/build.config.ts
@@ -69,6 +69,12 @@ export default defineBuildConfig({
             declaration: true,
             format: 'esm',
         },
+        {
+            builder: 'copy',
+            input: '../../',
+            outDir: './',
+            pattern: ['LICENSE'],
+        },
         ...getConfig({
             input: './src/components',
             outDir: 'components',

--- a/packages/uniwind/package.json
+++ b/packages/uniwind/package.json
@@ -72,7 +72,8 @@
         "vite",
         "uniwind.css",
         "types.d.ts",
-        "readme.md"
+        "readme.md",
+        "LICENSE"
     ],
     "dependencies": {
         "@tailwindcss/node": "4.1.17",


### PR DESCRIPTION
## Description

I noticed that the `LICENSE` file was missing from the published npm package.
This PR adds the `LICENSE` file to the package by copying it from the root directory during the build process and including it in the `files` list in `package.json`.

## Changes

- Updated `build.config.ts` to copy the `LICENSE` file from the project root.
- Added `LICENSE` to the `files` array in `package.json`.
