### PR TITLE
fix: compare css contents correctly before writing file

### DIFF
--- a/packages/uniwind/src/css/index.ts
+++ b/packages/uniwind/src/css/index.ts
@@ -10,21 +10,23 @@ export const buildCSS = async (themes: Array<string>, input: string) => {
     const variants = generateCSSForVariants()
     const insets = generateCSSForInsets()
     const themesCSS = await generateCSSForThemes(themes, input)
-    const cssFile = path.join(dirname, '../../uniwind.css')
-    const oldCSSFile = fs.existsSync(cssFile)
-        ? fs.readFileSync(cssFile, 'utf-8')
+    const cssFilePath = path.join(dirname, '../../uniwind.css')
+    const oldCSSFile = fs.existsSync(cssFilePath)
+        ? fs.readFileSync(cssFilePath, 'utf-8')
         : ''
 
-    if (oldCSSFile === cssFile) {
+    const newCssFile = [
+        variants,
+        insets,
+        themesCSS,
+    ].join('\n')
+
+    if (oldCSSFile === newCssFile) {
         return
     }
 
     fs.writeFileSync(
-        cssFile,
-        [
-            variants,
-            insets,
-            themesCSS,
-        ].join('\n'),
+        cssFilePath,
+        newCssFile,
     )
 }


### PR DESCRIPTION
I noticed the `buildCSS` function seems to be doing an incorrect comparison:

```ts
// This is a file path
const cssFile = path.join(dirname, '../../uniwind.css')

// This is file contents
const oldCSSFile = fs.existsSync(cssFile)
  ? fs.readFileSync(cssFile, 'utf-8')
  : ''

// These will never be equal
if (oldCSSFile === cssFile) {
  return
}
```