### PR TITLE
fix: filter out contextType when copying component properties

### DIFF
--- a/packages/uniwind/src/components/utils.ts
+++ b/packages/uniwind/src/components/utils.ts
@@ -1,7 +1,7 @@
 export const copyComponentProperties = <T extends object>(Component: T, UniwindComponent: any): T => {
     Object.entries(Component).forEach(([key, value]) => {
         // Filter out the keys we don't want to copy
-        if (['$$typeof', 'render'].includes(key)) {
+        if (['$$typeof', 'render', 'contextType'].includes(key)) {
             return
         }
 


### PR DESCRIPTION
This PR fixes a React runtime warning encountered during tests by excluding contextType from being copied in copyComponentProperties.

## Problem

While running virtualized-list tests, React logs the following error:

```bash
Unknown: Function components do not support contextType.
```

The error occurs because copyComponentProperties copies contextType onto function components, which React does not support. This causes a noisy console error during rendering in tests.

## Solution

- Add contextType to the excluded properties list in copyComponentProperties
- Ensure contextType is not applied to function components during property copying

## Result

- Eliminates the React warning during test execution
- Keeps behavior consistent with React’s component type constraints
- No functional changes to component behavior

## Tests

- Existing tests pass
- No new warnings appear in virtualized-list.test.tsx
