### PR TITLE
fix(web): add cjs dirname for storybook

### DIFF
--- a/packages/uniwind/src/vite/vite.ts
+++ b/packages/uniwind/src/vite/vite.ts
@@ -14,8 +14,9 @@ type UniwindConfig = {
     dtsFile?: string
 }
 
+const dirname = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname
 const componentPath = path.resolve(
-    import.meta.dirname,
+    dirname,
     '../module/components/web/index.js',
 )
 


### PR DESCRIPTION
It looks like storybook 9 loads configs in CJS, while Storybook 10 and later use ESM.
https://github.com/storybookjs/storybook/issues/31874

Fixes: https://github.com/uni-stack/uniwind/issues/259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility for path resolution across different module environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->