### PR TITLE
fix: enhance nativeResolver to exclude react-native internals

### DIFF
--- a/packages/uniwind/src/metro/resolvers.ts
+++ b/packages/uniwind/src/metro/resolvers.ts
@@ -47,13 +47,9 @@ export const nativeResolver = ({
 }: ResolverConfig) => {
     const resolution = resolver(context, moduleName, platform)
     const isInternal = isFromThisModule(context.originModulePath)
-    const isReactNativeIndex = context.originModulePath.endsWith(
-        `react-native${sep}index.js`,
-    )
-
     const isFromReactNative = context.originModulePath.includes(`${sep}react-native${sep}`)
 
-    if (isInternal || resolution.type !== 'sourceFile' || isReactNativeIndex || isFromReactNative) {
+    if (isInternal || resolution.type !== 'sourceFile' || isFromReactNative) {
         return resolution
     }
 


### PR DESCRIPTION
## Fix Summary

Problem: Android crash with "Element type is invalid: expected a string... but got: undefined" in Button component.

Root cause: The metro resolver was redirecting imports from inside React Native's own components to uniwind's wrapped versions, causing circular dependencies.

Imports originating from within react-native itself are now excluded from redirection, preventing the circular dependency.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened detection of React Native internal origins so the native resolver short-circuits more reliably, improving handling and consistency for native framework sources during bundling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->