### PR TITLE
fix: update nativeResolver to exclude @react-native paths for resolution

### DIFF
--- a/packages/uniwind/src/metro/resolvers.ts
+++ b/packages/uniwind/src/metro/resolvers.ts
@@ -48,6 +48,7 @@ export const nativeResolver = ({
     const resolution = resolver(context, moduleName, platform)
     const isInternal = isFromThisModule(context.originModulePath)
     const isFromReactNative = context.originModulePath.includes(`${sep}react-native${sep}`)
+        || context.originModulePath.includes(`${sep}@react-native${sep}`)
 
     if (isInternal || resolution.type !== 'sourceFile' || isFromReactNative) {
         return resolution


### PR DESCRIPTION
### Why

React Native's `VirtualizedList` lives in `@react-native/virtualized-lists` package, and it imports `ScrollView` from `'react-native'`:

```javascript
// node_modules/@react-native/virtualized-lists/Lists/VirtualizedList.js
import {
  ScrollView,
  View,
  // ...
} from 'react-native';
```

The Metro resolver was checking if an import originated from within `react-native/`:

```typescript
const isFromReactNative = context.originModulePath.includes(
    `${sep}react-native${sep}`,
)
```

But `@react-native/virtualized-lists` has a path like:
```
/node_modules/@react-native/virtualized-lists/Lists/VirtualizedList.js
```

This doesn't match `react-native/` - it matches `@react-native/`. So the resolver was transforming the internal `ScrollView` import to Uniwind's ScrollView, causing:

ScrollView ShadowNode to override ViurtualizedList ShadowNode.

### The Fix

Added `@react-native/` to the exclusion check:

```typescript
const isFromReactNative = context.originModulePath.includes(
    `${sep}react-native${sep}`,
) || context.originModulePath.includes(`${sep}@react-native${sep}`)
```

Now imports originating from any `@react-native/*` package (like `@react-native/virtualized-lists`) are not transformed, so the internal ScrollView stays as React Native's native ScrollView instead of becoming Uniwind's wrapped version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of React Native scoped modules in the build resolution system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->