### PR TITLE
fix: exclude .txt and .md files from scanner

### DIFF
--- a/packages/uniwind/src/metro/compileVirtual.ts
+++ b/packages/uniwind/src/metro/compileVirtual.ts
@@ -31,6 +31,11 @@ export const compileVirtual = async ({ css, cssPath, platform, themes, polyfills
                 pattern: '**/*',
                 base: path.dirname(cssPath),
             },
+            {
+                negated: true,
+                pattern: '**/*.{txt,md}',
+                base: path.dirname(cssPath),
+            },
         ],
     })
     const tailwindCSS = compiler.build(candidates ?? scanner.scan())


### PR DESCRIPTION
#282

Added negated=true and pattern to exclude `.txt` and `.md` files from scanner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated file processing configuration to exclude text and markdown files from build processing, improving build efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->