### PR TITLE
fix: resolve react native directories that are not node_modules

### DIFF
--- a/packages/uniwind/src/metro/resolvers.ts
+++ b/packages/uniwind/src/metro/resolvers.ts
@@ -52,11 +52,16 @@ export const nativeResolver = ({
     }
 
     const isInternal = cachedComponentsBasePath !== '' && context.originModulePath.startsWith(cachedComponentsBasePath)
+    const isFromNodeModules = context.originModulePath.includes(`${sep}node_modules${sep}`)
     const isFromReactNative = context.originModulePath.includes(`${sep}react-native${sep}`)
         || context.originModulePath.includes(`${sep}@react-native${sep}`)
     const isReactNativeAnimated = context.originModulePath.includes(`${sep}Animated${sep}components${sep}`)
 
-    if (isInternal || resolution.type !== 'sourceFile' || (isFromReactNative && !isReactNativeAnimated)) {
+    if (
+        isInternal // Is from uniwind
+        || resolution.type !== 'sourceFile' // Is not a source file
+        || (isFromReactNative && isFromNodeModules && !isReactNativeAnimated) // Is from react-native but not Animated
+    ) {
         return resolution
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
  * Improved module resolution handling for React Native dependencies. The resolver now more accurately determines when to bypass resolution by better distinguishing between internal and external code, preventing internal paths from being incorrectly skipped while preserving proper handling of React Native modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->