### PR TITLE
fix: support both new and old ColorSchemeName in RN

### DIFF
--- a/packages/uniwind/src/core/config/config.common.ts
+++ b/packages/uniwind/src/core/config/config.common.ts
@@ -5,7 +5,7 @@ import { CSSVariables, GenerateStyleSheetsCallback, ThemeName } from '../types'
 
 const SYSTEM_THEME = 'system' as const
 const RN_VERSION = Platform.constants.reactNativeVersion.minor
-const UNSPECIFIED_THEME = RN_VERSION >= 0.82 ? 'unspecified' : undefined
+const UNSPECIFIED_THEME = RN_VERSION >= 82 ? 'unspecified' : undefined
 
 export class UniwindConfigBuilder {
     protected themes = ['light', 'dark']


### PR DESCRIPTION
fix #323 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer React Native releases to ensure consistent color-scheme handling and theme application across platforms (web and native).
  * Treats an "unspecified" system appearance as Light and uses a stable fallback on non-web platforms to avoid incorrect or missing theme states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->