### PR TITLE
fix: updateCSSVariable only for the same theme

### DIFF
--- a/packages/uniwind/src/core/config/config.native.ts
+++ b/packages/uniwind/src/core/config/config.native.ts
@@ -39,11 +39,14 @@ class UniwindConfigBuilder extends UniwindConfigBuilderBase {
             const value = getValue()
             const runtimeThemeVariables = UniwindStore.runtimeThemeVariables.get(theme) ?? {}
 
-            Object.defineProperty(UniwindStore.vars, varName, {
-                configurable: true,
-                enumerable: true,
-                get: () => value,
-            })
+            if (theme === this.currentTheme) {
+                Object.defineProperty(UniwindStore.vars, varName, {
+                    configurable: true,
+                    enumerable: true,
+                    get: () => value,
+                })
+            }
+
             Object.defineProperty(runtimeThemeVariables, varName, {
                 configurable: true,
                 enumerable: true,

--- a/packages/uniwind/src/core/config/config.ts
+++ b/packages/uniwind/src/core/config/config.ts
@@ -23,7 +23,10 @@ class UniwindConfigBuilder extends UniwindConfigBuilderBase {
 
             runtimeCSSVariables[varName] = varValue
             this.runtimeCSSVariables.set(theme, runtimeCSSVariables)
-            this.applyCSSVariable(varName, varValue)
+
+            if (theme === this.currentTheme) {
+                this.applyCSSVariable(varName, varValue)
+            }
         })
 
         if (theme === this.currentTheme) {


### PR DESCRIPTION
fixes #343 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed theme variable updates to only apply CSS variables for the currently active theme, preventing unintended global variable exposure from inactive themes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->