### PR TITLE
fix: use react-native-safe-area-context instead of deprecated SafeAreaView

### DIFF
--- a/packages/uniwind/package.json
+++ b/packages/uniwind/package.json
@@ -86,6 +86,7 @@
     "peerDependencies": {
         "react": ">=19.0.0",
         "react-native": ">=0.81.0",
+        "react-native-safe-area-context": ">=4.0.0",
         "tailwindcss": ">=4"
     },
     "devDependencies": {

--- a/packages/uniwind/src/components/native/SafeAreaView.tsx
+++ b/packages/uniwind/src/components/native/SafeAreaView.tsx
@@ -1,8 +1,8 @@
-import { SafeAreaView as RNSafeAreaView, ViewProps } from 'react-native'
+import { SafeAreaView as RNSafeAreaView, type SafeAreaViewProps } from 'react-native-safe-area-context'
 import { copyComponentProperties } from '../utils'
 import { useStyle } from './useStyle'
 
-export const SafeAreaView = copyComponentProperties(RNSafeAreaView, (props: ViewProps) => {
+export const SafeAreaView = copyComponentProperties(RNSafeAreaView, (props: SafeAreaViewProps) => {
     const style = useStyle(props.className, props)
 
     return (

--- a/packages/uniwind/src/components/web/SafeAreaView.tsx
+++ b/packages/uniwind/src/components/web/SafeAreaView.tsx
@@ -1,8 +1,8 @@
-import { SafeAreaView as RNSafeAreaView, ViewProps } from 'react-native'
+import { SafeAreaView as RNSafeAreaView, type SafeAreaViewProps } from 'react-native-safe-area-context'
 import { copyComponentProperties } from '../utils'
 import { toRNWClassName } from './rnw'
 
-export const SafeAreaView = copyComponentProperties(RNSafeAreaView, (props: ViewProps) => {
+export const SafeAreaView = copyComponentProperties(RNSafeAreaView, (props: SafeAreaViewProps) => {
     return (
         <RNSafeAreaView
             {...props}


### PR DESCRIPTION
## Summary

- Replace deprecated `SafeAreaView` import from `react-native` with `react-native-safe-area-context` in both native and web components
- Add `react-native-safe-area-context` as a peer dependency

## Problem

`SafeAreaView` from `react-native` has been deprecated and will be removed in a future release. The React Native team recommends using `react-native-safe-area-context` instead.

Additionally, this causes a development warning to appear even when `SafeAreaView` is not directly used. When importing anything from `uniwind`, React Fast Refresh enumerates all exports which triggers the deprecation getter for `SafeAreaView`.

## Solution

Import `SafeAreaView` from `react-native-safe-area-context` instead of `react-native`. Added as a peer dependency since most React Native projects already have it installed (it's required by React Navigation and other common libraries).

## Changes

- `src/components/native/SafeAreaView.tsx` - Updated import
- `src/components/web/SafeAreaView.tsx` - Updated import
- `package.json` - Added peer dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced SafeAreaView component to properly handle safe areas and screen intrusions (notches, status bars, etc.) on both native and web platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->