### PR TITLE
feat: optimize cache key generation for better performance

### DIFF
--- a/packages/uniwind/src/core/native/store.ts
+++ b/packages/uniwind/src/core/native/store.ts
@@ -11,9 +11,10 @@ type StylesResult = {
     styles: RNStyle
     dependencies: Array<StyleDependency>
     dependencySum: number
+    hasDataAttributes: boolean
 }
 
-const emptyState: StylesResult = { styles: {}, dependencies: [], dependencySum: 0 }
+const emptyState: StylesResult = { styles: {}, dependencies: [], dependencySum: 0, hasDataAttributes: false }
 
 class UniwindStoreBuilder {
     runtime = UniwindRuntime
@@ -28,11 +29,16 @@ class UniwindStoreBuilder {
             return emptyState
         }
 
-        const stateFlags = (state?.isDisabled ? 4 : 0) | (state?.isFocused ? 2 : 0) | (state?.isPressed ? 1 : 0)
+        const stateFlags = (state ? 8 : 0)
+            | (state?.isDisabled ? 4 : 0)
+            | (state?.isFocused ? 2 : 0)
+            | (state?.isPressed ? 1 : 0)
         const cacheKey = `${className}:${stateFlags}`
-        const cached = this.cache.get(cacheKey)
 
-        if (cached) return cached
+        if (this.cache.has(cacheKey)) {
+            return this.cache.get(cacheKey)!
+        }
+
         const result = this.resolveStyles(className, componentProps, state)
 
         // Don't cache styles that depend on data attributes


### PR DESCRIPTION
I tested this new cache system using bitwise against uniwind 1.3.0 and saw a 1.17× difference in performance, @Brentlok kindly review and check if it's worth merging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal style caching and key generation to reduce collisions and improve performance.
* **Bug Fix**
  * Styles that include data attributes are no longer reused from cache, ensuring correct recomputation and more reliable styling results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->