### PR TITLE
fix(vite): fix RNW styles in production builds

### DIFF
--- a/packages/uniwind/src/vite/vite.ts
+++ b/packages/uniwind/src/vite/vite.ts
@@ -38,6 +38,16 @@ export const uniwind = ({
 
     return {
         name: 'uniwind',
+        enforce: 'pre',
+        resolveId: (source, importer) => {
+            const normalizedSource = normalizePath(source)
+            const isTarget = source === './createOrderedCSSStyleSheet'
+                || normalizedSource.endsWith('react-native-web/dist/exports/StyleSheet/dom/createOrderedCSSStyleSheet.js')
+
+            if (isTarget && importer !== undefined && normalizePath(importer).includes('react-native-web/dist/exports/StyleSheet')) {
+                return styleSheetPath
+            }
+        },
         config: () => ({
             css: {
                 transformer: 'lightningcss',


### PR DESCRIPTION
I'm not a vite genious so I'm kinda just leaning on trial/error here but I believe this works for all scenarios now. Feel free to apply some other fix and close this if it doesn't make sense.
Thanks for your work on uniwind, its awesome.

## Summary
- Fix Vite production builds where RNW/Tailwind styles were not applied by redirecting createOrderedCSSStyleSheet to the layered version.
- Run the redirect before vite-plugin-rnw so the patched file is used in production bundles.

## Testing
for apps/vite-example:
- bun run dev 
  - check that it looks ok
- bun run release
- bun run preview 
  - check that it looks ok 

Fixes #367