### PR TITLE
fix: preserve start/end spacing properties

### DIFF
--- a/packages/uniwind/src/metro/processor/rn.ts
+++ b/packages/uniwind/src/metro/processor/rn.ts
@@ -177,6 +177,8 @@ export class RN {
                 x => {
                     if (x.includes('padding') || x.includes('margin')) {
                         return x
+                            .replace('InlineStart', 'Start')
+                            .replace('InlineEnd', 'End')
                             .replace('Inline', 'Horizontal')
                             .replace('Block', 'Vertical')
                     }

--- a/packages/uniwind/tests/native/styles-parsing/spacing.test.tsx
+++ b/packages/uniwind/tests/native/styles-parsing/spacing.test.tsx
@@ -38,6 +38,8 @@ describe('Spacing', () => {
                 <View className="pr-1" testID="pr-1" />
                 <View className="pb-1" testID="pb-1" />
                 <View className="pl-1" testID="pl-1" />
+                <View className="ps-1" testID="ps-1" />
+                <View className="pe-1" testID="pe-1" />
             </React.Fragment>,
         )
 
@@ -54,6 +56,8 @@ describe('Spacing', () => {
         expect(getStylesFromId('pr-1').paddingRight).toBe(4)
         expect(getStylesFromId('pb-1').paddingBottom).toBe(4)
         expect(getStylesFromId('pl-1').paddingLeft).toBe(4)
+        expect(getStylesFromId('ps-1').paddingStart).toBe(4)
+        expect(getStylesFromId('pe-1').paddingEnd).toBe(4)
     })
 
     test('Margin', () => {
@@ -67,6 +71,8 @@ describe('Spacing', () => {
                 <View className="mb-1" testID="mb-1" />
                 <View className="ml-1" testID="ml-1" />
                 <View className="-ml-1" testID="-ml-1" />
+                <View className="ms-1" testID="ms-1" />
+                <View className="me-1" testID="me-1" />
             </React.Fragment>,
         )
 
@@ -84,6 +90,8 @@ describe('Spacing', () => {
         expect(getStylesFromId('mb-1').marginBottom).toBe(4)
         expect(getStylesFromId('ml-1').marginLeft).toBe(4)
         expect(getStylesFromId('-ml-1').marginLeft).toBe(-4)
+        expect(getStylesFromId('ms-1').marginStart).toBe(4)
+        expect(getStylesFromId('me-1').marginEnd).toBe(4)
     })
 
     test('Insets', () => {


### PR DESCRIPTION
This pull request adds support for spacing utilities (`paddingStart`, `paddingEnd`, `marginStart`, `marginEnd`).

Previous behaviour was incorrectly replacing `InlineStart` and `InlineEnd` suffixes with `HorizontalStart`/`VerticalStart`, which isn't correct.

```js
useResolveClassNames('ms-auto');
// result: {"marginHorizontalStart": "auto"}
// expected: {"marginStart": "auto"}
```

I added extra test cases to both padding and margin to make sure it resolves as expected without breaking the existing cases. Also tested it's working by applying a patch package to my app.

I tried to find any issues asking about this, but found none. Please let me know if this was intended for some reason, although I think this was missed by mistake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CSS to React Native style conversion with improved handling of logical directional properties (start/end) for padding and margin spacing.

* **Tests**
  * Added test coverage validating start/end directional padding and margin properties convert correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->