### PR TITLE
fix: fontScale and pixelRatio without arguments

### DIFF
--- a/packages/uniwind/src/metro/processor/functions.ts
+++ b/packages/uniwind/src/metro/processor/functions.ts
@@ -110,10 +110,18 @@ export class Functions {
         }
 
         if (fn.name === 'pixelRatio') {
+            if (fn.arguments.length === 0) {
+                return 'rt.pixelRatio(1)'
+            }
+
             return `rt.pixelRatio(${this.Processor.CSS.processValue(fn.arguments)})`
         }
 
         if (fn.name === 'fontScale') {
+            if (fn.arguments.length === 0) {
+                return 'rt.fontScale(1)'
+            }
+
             return `rt.fontScale(${this.Processor.CSS.processValue(fn.arguments)})`
         }
 

--- a/packages/uniwind/tests/native/styles-parsing/css-functions.test.tsx
+++ b/packages/uniwind/tests/native/styles-parsing/css-functions.test.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import View from '../../../src/components/native/View'
+import { renderUniwind } from '../utils'
+
+describe('Custom CSS Functions', () => {
+    test('fontScale', () => {
+        const { getStylesFromId } = renderUniwind(
+            <React.Fragment>
+                <View className="w-[fontScale()]" testID="font-scale" />
+                <View className="w-[fontScale(2)]" testID="font-scale-2" />
+            </React.Fragment>,
+        )
+
+        expect(getStylesFromId('font-scale').width).toBe(1)
+        expect(getStylesFromId('font-scale-2').width).toBe(2)
+    })
+
+    test('pixelRatio', () => {
+        const { getStylesFromId } = renderUniwind(
+            <React.Fragment>
+                <View className="w-[pixelRatio()]" testID="pixel-ratio" />
+                <View className="w-[pixelRatio(2)]" testID="pixel-ratio-2" />
+            </React.Fragment>,
+        )
+
+        expect(getStylesFromId('pixel-ratio').width).toBe(1)
+        expect(getStylesFromId('pixel-ratio-2').width).toBe(2)
+    })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSS functions (pixelRatio and fontScale) now properly handle cases when called without arguments, providing sensible default values.

* **Tests**
  * Added test coverage for pixelRatio() and fontScale() CSS functions to verify correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->