### PR TITLE
fix: width & height defensive checks for slow android reload cycles 

### DIFF
--- a/packages/uniwind/src/core/native/store.ts
+++ b/packages/uniwind/src/core/native/store.ts
@@ -109,8 +109,8 @@ class UniwindStoreBuilder {
                 }
 
                 if (
-                    style.minWidth > this.runtime.screen.width
-                    || style.maxWidth < this.runtime.screen.width
+                    (this.runtime.screen?.width && style.minWidth > this.runtime.screen.width)
+                    || (this.runtime.screen?.width && style.maxWidth < this.runtime.screen.width)
                     || (style.theme !== null && this.runtime.currentThemeName !== style.theme)
                     || (style.orientation !== null && this.runtime.orientation !== style.orientation)
                     || (style.rtl !== null && this.runtime.rtl !== style.rtl)

--- a/packages/uniwind/src/metro/processor/units.ts
+++ b/packages/uniwind/src/metro/processor/units.ts
@@ -17,9 +17,9 @@ export class Units {
                 case 'px':
                     return this.replaceInfinity(length.value)
                 case 'vw':
-                    return `rt.screen.width * ${length.value / 100}`
+                    return `(rt.screen?.width || 0) * ${length.value / 100}`
                 case 'vh':
-                    return `rt.screen.height * ${length.value / 100}`
+                    return `(rt.screen?.height || 0) * ${length.value / 100}`
                 case 'rem':
                     return length.value * this.Processor.vars['--uniwind-em']
                 case 'em':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of responsive style calculations when screen dimensions are unavailable, preventing potential runtime errors in width-based styling and viewport unit conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->