### PR TITLE
fix: gradient parsing with % and variables

### DIFF
--- a/packages/uniwind/src/metro/utils/common.ts
+++ b/packages/uniwind/src/metro/utils/common.ts
@@ -45,6 +45,7 @@ export const addMissingSpaces = (str: string) =>
         x => x.trim(),
         x => x.replace(/([^ {])this/g, '$1 this'),
         x => x.replace(/\](?=\d)/g, '] '),
+        x => x.replace(/\](?=")/g, '] '),
         x => x.replace(/\)(?=\S)/g, ') '),
         x => x.replace(/(?<!^)(?<!\s)"(?=\d)/g, '" '),
     )

--- a/packages/uniwind/tests/test.css
+++ b/packages/uniwind/tests/test.css
@@ -4,6 +4,7 @@
 :root {
   --foo: 120 50% 50%;
   --bar: 0.7 0.1 141;
+  --my-gradient: linear-gradient(90deg, var(--color-foo) 0%, var(--color-bar) 100%);
 }
 
 @theme {


### PR DESCRIPTION
fix #400 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing handling when closing brackets are followed by quotation marks

* **New Features**
  * Added a new CSS custom property for gradient definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->