### PR TITLE
fix: treat invalid js expression as plain string

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,8 @@
 
 # Exclude Ruby
 *.rb linguist-detectable=false
+Podfile linguist-detectable=false
+Gemfile linguist-detectable=false
 
 # Exclude Swift
 *.swift linguist-detectable=false

--- a/packages/uniwind/src/metro/utils/serialize.ts
+++ b/packages/uniwind/src/metro/utils/serialize.ts
@@ -29,10 +29,16 @@ const parseStringValue = (value: string) => {
 
         // Expressions that need to be wrapped with ${}
         const endsWithComma = token.endsWith(',')
+        const expr = endsWithComma ? token.slice(0, -1) : token
+
+        // Only wrap in ${} if the expression is valid JS — otherwise treat as plain string
+        if (!isValidJSValue(expr)) {
+            return token
+        }
 
         return [
             '${',
-            endsWithComma ? token.slice(0, -1) : token,
+            expr,
             '}',
             endsWithComma ? ',' : '',
         ].join('')

--- a/packages/uniwind/tests/native/styles-parsing/invalid.test.tsx
+++ b/packages/uniwind/tests/native/styles-parsing/invalid.test.tsx
@@ -1,0 +1,10 @@
+// Regression tests when tailwind compiler recognized something as a class that really wasn't one
+const _ = `[aero-chip:label=Runway|value=09R]`
+
+describe('Invalid classes', () => {
+    test('Invalid class-like strings in source files do not break serialization', () => {
+        // The presence of _ above ensures the Tailwind scanner picks up the invalid candidate.
+        // The test passes as long as the setup (compileVirtual) does not throw.
+        expect(true).toBe(true)
+    })
+})


### PR DESCRIPTION
fixes #409 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of expressions to prevent invalid syntax from breaking serialization processes.

* **Tests**
  * Added regression test coverage for invalid class-like strings to ensure serialization stability.

* **Chores**
  * Updated repository configuration to exclude Ruby-related build files from language detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->