### PR TITLE
fix: guard against display: box from line-clamp-* classes

### DIFF
--- a/packages/uniwind/src/metro/processor/rn.ts
+++ b/packages/uniwind/src/metro/processor/rn.ts
@@ -163,9 +163,9 @@ const cssToRNMap: Record<string, (value: any) => Record<string, any>> = {
         fontVariant: value,
     }),
     display: value => {
-        if (value === 'box') {
+        if (value === '"box"') {
             return {
-                display: 'flex',
+                display: '"flex"',
             }
         }
         return {

--- a/packages/uniwind/tests/native/styles-parsing/layout.test.tsx
+++ b/packages/uniwind/tests/native/styles-parsing/layout.test.tsx
@@ -76,6 +76,7 @@ describe('Layout', () => {
             <React.Fragment>
                 {/* <View className="hidden" testID="hidden" /> */}
                 <View className="flex" testID="flex" />
+                <View className="[display:-webkit-box]" testID="box" />
                 <View className="overflow-hidden" testID="overflow-hidden" />
                 <View className="overflow-visible" testID="overflow-visible" />
             </React.Fragment>,
@@ -83,6 +84,7 @@ describe('Layout', () => {
 
         // expect(getStylesFromId('hidden').display).toBe('none')
         expect(getStylesFromId('flex').display).toBe('flex')
+        expect(getStylesFromId('box').display).toBe('flex')
         expect(getStylesFromId('overflow-hidden').overflow).toBe('hidden')
         expect(getStylesFromId('overflow-visible').overflow).toBe('visible')
     })


### PR DESCRIPTION
In the device logs for my app I see a lot of warnings coming from Yoga:
```
E0303 12:17:56.354928 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:17:56.360345 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:16.918680 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:16.925693 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:16.932026 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:16.939231 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:16.944594 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:16.949831 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:19.482690 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:19.489756 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:19.495424 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:19.504101 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:51.864795 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:51.872054 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:51.877475 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:51.884375 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:51.892674 1809575936 conversions.h:425] Could not parse yoga::Display: box
E0303 12:18:51.899590 1809575936 conversions.h:425] Could not parse yoga::Display: box
```

This appears to come from the [`line-clamp-*` class](https://tailwindcss.com/docs/line-clamp), where Uniwind is translating `display: -webkit-box;` into `display: box`. This causes Yoga receive a value of `box` for  the `display` property that it doesn't recognise.

My proposed fix is to map `display: box` to `display: flex` in `cssToRNMap`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display property handling so legacy "-webkit-box" display values correctly render as "flex" in React Native layouts.
* **Tests**
  * Added test coverage to verify the new display behavior for legacy display values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->