### PR TITLE
chore: fix changelog's group variable and properly handle commits newline

### DIFF
--- a/packages/uniwind/cliff.toml
+++ b/packages/uniwind/cliff.toml
@@ -14,20 +14,17 @@ body = """
 {% endif -%}
 
 {% set order = ["🚀 Features", "🐛 Bug Fixes", "🔨 Refactoring", "⚡ Performance", "📚 Documentation", "🧪 Testing", "🏠 Chores", "📦 Other"] %}
-{% set grouped = commits | group_by(attribute="group") %}
-{% for group in order %}{% if group in grouped %}
+{% for group in order %}{% set group_commits = commits | filter(attribute="group", value=group) %}{% if group_commits | length > 0 %}
   ### {{ group }}
-  {% for commit in grouped[group] %}
+  {%- for commit in group_commits %}
     {%- if commit.remote.pr_title -%}
       {%- set commit_message = commit.remote.pr_title -%}
     {%- else -%}
       {%- set commit_message = commit.message -%}
-    {%- endif -%}
-    * {{ commit_message | split(pat="\n") | first | trim }}\
-      {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif -%}
-      {% if commit.remote.pr_number %} in \
-        [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }})\
-      {%- endif %}
+    {%- endif %}
+  * {{ commit_message | split(pat="\n") | first | trim -}}
+    {%- if commit.remote.username %} by @{{ commit.remote.username }}{% endif -%}
+    {%- if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}){% endif %}
   {%- endfor %}
 {% endif %}{% endfor -%}
 


### PR DESCRIPTION
The changelog.sh produces an error when run, and when you check `CHANGELOG.md`, multiple commits under a group newlines are not properly handled.

```
ERROR git_cliff                 > Template render error:
Variable `grouped[group]` not found in context while rendering 'body': the evaluated version was `grouped."🚀 Features"`. Maybe the index is out of bounds?
```

This PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized changelog generation process by streamlining how commits are grouped and filtered.
  * Improved changelog output formatting for a more compact and cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->