### PR TITLE
fix: validate serialized style entries individually instead of all-or-nothing

### DIFF
--- a/packages/uniwind/src/metro/utils/serialize.ts
+++ b/packages/uniwind/src/metro/utils/serialize.ts
@@ -1,5 +1,5 @@
 import { Logger } from '../logger'
-import { addMissingSpaces, isNumber, isValidJSValue, pipe, roundToPrecision, smartSplit } from './common'
+import { addMissingSpaces, isNumber, isValidJSValue, roundToPrecision, smartSplit } from './common'
 
 const parseStringValue = (value: string) => {
     if (isValidJSValue(value)) {
@@ -97,26 +97,25 @@ export const serialize = (value: any): string => {
 }
 
 export const serializeJSObject = (obj: Record<string, any>, serializer: (key: string, value: string) => string) => {
-    const serializedObject = pipe(obj)(
-        Object.entries,
-        entries => entries.map(([key, value]) => serializer(key, serialize(value))),
-        entries => entries.join(','),
-        result => {
-            if (result === '') {
-                return ''
-            }
+    const entries = Object.entries(obj).map(([key, value]) => serializer(key, serialize(value)))
 
-            return `${result},`
-        },
-    )
+    const validEntries = entries.filter(entry => {
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+            new Function(`function v() { const o = ({ ${entry} }) }`)
+            return true
+        } catch {
+            return false
+        }
+    })
 
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-        new Function(`function validateJS() { const obj = ({ ${serializedObject} }) }`)
-    } catch {
-        Logger.error('Failed to serialize javascript object')
+    if (validEntries.length < entries.length) {
+        Logger.warn(`Skipped ${entries.length - validEntries.length} invalid style entries during serialization`)
+    }
+
+    if (validEntries.length === 0) {
         return ''
     }
 
-    return serializedObject
+    return `${validEntries.join(',')},`
 }


### PR DESCRIPTION
## Summary

- `serializeJSObject` currently validates the **entire** serialized stylesheet with a single `new Function()` call. If any single entry produces invalid JS (e.g. from a false-positive class name like `[tid:%@]` picked up by the Oxide scanner), the entire stylesheet is discarded, resulting in `stylesheet: {}` and zero styles at runtime in production builds.
- This changes validation to **per-entry**: invalid entries are skipped with a warning while all valid styles (500+ entries) are preserved.
- Changed `Logger.error` to `Logger.warn` since the build continues successfully

## Reproduction

1. Any Expo project with uniwind in production mode
2. Have any file in the scanned source directory containing a string like `[tid:%@]` (common in iOS/Objective-C logs, Sentry configs, etc.)
3. Run `npx expo export --platform ios`
4. The generated bundle has `stylesheet: {}`, all styles missing

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 110 existing tests pass (37 native + 2 web suites)
- [x] Lint passes
- [x] Build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization stability by validating entries and gracefully skipping invalid ones instead of causing failures.

* **Refactor**
  * Streamlined serialization logic with enhanced error handling that returns empty results for invalid data rather than propagating errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->