### PR TITLE
feat: export ThemeName and make themes public in Uniwind class

### DIFF
--- a/packages/uniwind/src/components/web/rnw.ts
+++ b/packages/uniwind/src/components/web/rnw.ts
@@ -4,7 +4,7 @@ import { StyleDependency } from '../../types'
 import './metro-injected'
 
 type UniwindWithThemes = {
-    themes: typeof Uniwind['themes']
+    themes: typeof Uniwind['_themes']
 }
 
 const addClassNameToRoot = () => {

--- a/packages/uniwind/src/core/config/config.common.ts
+++ b/packages/uniwind/src/core/config/config.common.ts
@@ -10,7 +10,7 @@ const RN_VERSION = Platform.constants?.reactNativeVersion?.minor ?? 0
 const UNSPECIFIED_THEME = RN_VERSION >= 82 ? 'unspecified' : undefined
 
 export class UniwindConfigBuilder {
-    protected themes = ['light', 'dark']
+    protected _themes = ['light', 'dark']
     #hasAdaptiveThemes = true
     #currentTheme = this.colorScheme as ThemeName
 
@@ -28,6 +28,10 @@ export class UniwindConfigBuilder {
                 UniwindListener.notify([StyleDependency.Theme])
             }
         })
+    }
+
+    get themes() {
+        return this._themes as Array<ThemeName>
     }
 
     get hasAdaptiveThemes() {
@@ -67,7 +71,7 @@ export class UniwindConfigBuilder {
                 return
             }
 
-            if (!this.themes.includes(theme)) {
+            if (!this._themes.includes(theme)) {
                 throw new Error(`Uniwind: You're trying to setTheme to '${theme}', but it was not registered.`)
             }
 
@@ -106,7 +110,7 @@ export class UniwindConfigBuilder {
     }
 
     protected __reinit(_: GenerateStyleSheetsCallback, themes: Array<string>) {
-        this.themes = themes
+        this._themes = themes
     }
 
     protected onThemeChange() {

--- a/packages/uniwind/src/index.ts
+++ b/packages/uniwind/src/index.ts
@@ -1,5 +1,6 @@
 export * from './components/ScopedTheme'
 export { Uniwind } from './core'
+export type { ThemeName } from './core/types'
 export { withUniwind } from './hoc'
 export type { ApplyUniwind, ApplyUniwindOptions } from './hoc/types'
 export { useCSSVariable, useResolveClassNames, useUniwind } from './hooks'


### PR DESCRIPTION
https://github.com/uni-stack/uniwind/discussions/459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public access to theme configuration through a new getter method.
  * Exported ThemeName type to support TypeScript development and improve type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->