### PR TITLE
Fix dark: prefix styles inside scoped themes ending with -dark

### DIFF
--- a/packages/uniwind/src/core/native/store.ts
+++ b/packages/uniwind/src/core/native/store.ts
@@ -134,7 +134,7 @@ class UniwindStoreBuilder {
                 if (
                     style.minWidth > this.runtime.screen.width
                     || style.maxWidth < this.runtime.screen.width
-                    || (style.theme !== null && theme !== style.theme)
+                    || (style.theme !== null && theme !== style.theme && !(style.theme === 'dark' && theme.endsWith('-dark')))
                     || (style.orientation !== null && this.runtime.orientation !== style.orientation)
                     || (style.rtl !== null && this.runtime.rtl !== style.rtl)
                     || (style.active !== null && state?.isPressed !== style.active)


### PR DESCRIPTION
## Problem

When using scoped themes like `yellow-dark`, all `dark:` prefixed styles are silently ignored. This happens because the theme matching logic in the store requires an exact match against the literal string `"dark"`, so `"dark" !== "yellow-dark"` causes all dark-variant styles to be skipped.

## Fix

Add an exception to the theme check so that `dark:` styles also apply when the active scoped theme name ends with `-dark`.

Single-line change in `packages/uniwind/src/core/native/store.ts`.

Fixes #470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dark-themed styles to properly apply across all dark theme variants, ensuring consistent styling regardless of specific theme variant names used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->