### PR TITLE
fix: read absolute cssPath instead of relative one in metro-transformer

### DIFF
--- a/packages/uniwind/src/metro/metro-transformer.ts
+++ b/packages/uniwind/src/metro/metro-transformer.ts
@@ -75,7 +75,7 @@ export const transform = async (
         themes: config.uniwind.themes,
         dtsPath: config.uniwind.dtsFile,
     })
-    const css = fs.readFileSync(filePath, 'utf-8')
+    const css = fs.readFileSync(cssPath, 'utf-8')
     const platform = getPlatform()
     const virtualCode = await compileVirtual({
         css,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS module resolution during the build process to correctly reference configured entry files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->