### PR TITLE
Fix CSS variable updates for scoped / non-global themes

### DIFF
--- a/packages/uniwind/src/components/native/useStyle.ts
+++ b/packages/uniwind/src/components/native/useStyle.ts
@@ -12,7 +12,9 @@ export const useStyle = (className: string | undefined, componentProps: Record<s
 
     useLayoutEffect(() => {
         if (__DEV__ || styleState.dependencies.length > 0) {
-            const dispose = UniwindListener.subscribe(rerender, styleState.dependencies)
+            const dispose = UniwindListener.subscribe(rerender, styleState.dependencies, {
+                shouldNotifyVariables: (theme) => theme === (uniwindContext.scopedTheme ?? UniwindStore.runtime.currentThemeName),
+            })
 
             return dispose
         }

--- a/packages/uniwind/src/core/config/config.native.ts
+++ b/packages/uniwind/src/core/config/config.native.ts
@@ -44,9 +44,7 @@ class UniwindConfigBuilder extends UniwindConfigBuilderBase {
             })
         })
 
-        if (theme === this.currentTheme) {
-            UniwindListener.notify([StyleDependency.Variables])
-        }
+        UniwindListener.notifyVariables(theme)
     }
 
     updateInsets(insets: Insets) {

--- a/packages/uniwind/src/core/config/config.ts
+++ b/packages/uniwind/src/core/config/config.ts
@@ -1,4 +1,3 @@
-import { StyleDependency } from '../../types'
 import { UniwindListener } from '../listener'
 import { Logger } from '../logger'
 import { CSSVariables, ThemeName } from '../types'
@@ -9,6 +8,16 @@ class UniwindConfigBuilder extends UniwindConfigBuilderBase {
 
     constructor() {
         super()
+    }
+
+    getRuntimeCSSVariableValue(theme: ThemeName, varName: string): string | number | undefined {
+        const vars = this.runtimeCSSVariables.get(theme)
+
+        if (!vars || !Object.prototype.hasOwnProperty.call(vars, varName)) {
+            return undefined
+        }
+
+        return vars[varName]
     }
 
     updateCSSVariables(theme: ThemeName, variables: CSSVariables) {
@@ -29,9 +38,7 @@ class UniwindConfigBuilder extends UniwindConfigBuilderBase {
             }
         })
 
-        if (theme === this.currentTheme) {
-            UniwindListener.notify([StyleDependency.Variables])
-        }
+        UniwindListener.notifyVariables(theme)
     }
 
     protected onThemeChange() {

--- a/packages/uniwind/src/core/listener.ts
+++ b/packages/uniwind/src/core/listener.ts
@@ -1,10 +1,13 @@
 import { StyleDependency } from '../types'
+import { ThemeName } from './types'
 
 type SubscribeOptions = {
     once?: boolean
+    shouldNotifyVariables?: (theme: ThemeName) => boolean
 }
 
 class UniwindListenerBuilder {
+    private notifyingVariablesTheme: ThemeName | null = null
     private listeners = {
         [StyleDependency.ColorScheme]: new Set<() => void>(),
         [StyleDependency.Theme]: new Set<() => void>(),
@@ -21,6 +24,12 @@ class UniwindListenerBuilder {
         dependencies.forEach(dep => {
             this.listeners[dep].forEach(callback => callback())
         })
+    }
+
+    notifyVariables(theme: ThemeName) {
+        this.notifyingVariablesTheme = theme
+        this.listeners[StyleDependency.Variables].forEach(callback => callback())
+        this.notifyingVariablesTheme = null
     }
 
     notifyAll() {
@@ -41,6 +50,14 @@ class UniwindListenerBuilder {
 
         dependencies.forEach(dep => {
             const wrappedListener = () => {
+                if (dep === StyleDependency.Variables && this.notifyingVariablesTheme !== null) {
+                    const shouldNotify = options?.shouldNotifyVariables?.(this.notifyingVariablesTheme) ?? true
+
+                    if (!shouldNotify) {
+                        return
+                    }
+                }
+
                 listener()
 
                 if (options?.once) {

--- a/packages/uniwind/src/core/native/store.ts
+++ b/packages/uniwind/src/core/native/store.ts
@@ -33,8 +33,9 @@ class UniwindStoreBuilder {
         }
 
         const isScopedTheme = uniwindContext.scopedTheme !== null
+        const theme = uniwindContext.scopedTheme ?? this.runtime.currentThemeName
         const cacheKey = `${className}${state?.isDisabled ?? false}${state?.isFocused ?? false}${state?.isPressed ?? false}${isScopedTheme}`
-        const cache = this.cache[uniwindContext.scopedTheme ?? this.runtime.currentThemeName]
+        const cache = this.cache[theme]
 
         if (!cache) {
             return emptyState
@@ -52,7 +53,10 @@ class UniwindStoreBuilder {
             UniwindListener.subscribe(
                 () => cache.delete(cacheKey),
                 result.dependencies,
-                { once: true },
+                {
+                    once: true,
+                    shouldNotifyVariables: (changedTheme) => changedTheme === theme,
+                },
             )
         }
 

--- a/packages/uniwind/src/core/web/getWebStyles.ts
+++ b/packages/uniwind/src/core/web/getWebStyles.ts
@@ -1,4 +1,5 @@
 import { generateDataSet } from '../../components/web/generateDataSet'
+import { Uniwind } from '../config/config'
 import { RNStyle, UniwindContextType } from '../types'
 import { CSSListener } from './cssListener'
 import { parseCSSValue } from './parseCSSValue'
@@ -108,6 +109,17 @@ export const getWebStyles = (
 export const getWebVariable = (name: string, uniwindContext: UniwindContextType) => {
     if (!dummyParent) {
         return undefined
+    }
+
+    const theme = uniwindContext.scopedTheme ?? Uniwind.currentTheme
+    const runtimeValue = Uniwind.getRuntimeCSSVariableValue(theme, name)
+
+    if (runtimeValue !== undefined) {
+        return parseCSSValue(
+            typeof runtimeValue === 'number'
+                ? `${runtimeValue}px`
+                : runtimeValue,
+        )
     }
 
     if (uniwindContext.scopedTheme !== null) {

--- a/packages/uniwind/src/hoc/withUniwind.native.tsx
+++ b/packages/uniwind/src/hoc/withUniwind.native.tsx
@@ -73,7 +73,9 @@ const withAutoUniwind = (Component: Component<AnyObject>) => (props: AnyObject) 
     const [, rerender] = useReducer(() => ({}), {})
 
     useLayoutEffect(() => {
-        const dispose = UniwindListener.subscribe(rerender, Array.from(new Set(dependencies)))
+        const dispose = UniwindListener.subscribe(rerender, Array.from(new Set(dependencies)), {
+            shouldNotifyVariables: (theme) => theme === (uniwindContext.scopedTheme ?? UniwindStore.runtime.currentThemeName),
+        })
 
         return dispose
     }, [dependencySum])
@@ -139,7 +141,9 @@ const withManualUniwind = (Component: Component<AnyObject>, options: Record<Prop
     const [, rerender] = useReducer(() => ({}), {})
 
     useLayoutEffect(() => {
-        const dispose = UniwindListener.subscribe(rerender, Array.from(new Set(dependencies)))
+        const dispose = UniwindListener.subscribe(rerender, Array.from(new Set(dependencies)), {
+            shouldNotifyVariables: (theme) => theme === (uniwindContext.scopedTheme ?? UniwindStore.runtime.currentThemeName),
+        })
 
         return dispose
     }, [dependencySum])

--- a/packages/uniwind/src/hoc/withUniwind.native.tsx
+++ b/packages/uniwind/src/hoc/withUniwind.native.tsx
@@ -22,6 +22,7 @@ export const withUniwind: WithUniwind = <
 
 const withAutoUniwind = (Component: Component<AnyObject>) => (props: AnyObject) => {
     const uniwindContext = useUniwindContext()
+    const effectiveTheme = uniwindContext.scopedTheme ?? UniwindStore.runtime.currentThemeName
     const { dependencies, generatedProps } = Object.entries(props).reduce((acc, [propName, propValue]) => {
         if (isColorClassProperty(propName)) {
             const colorProp = classToColor(propName)
@@ -74,11 +75,11 @@ const withAutoUniwind = (Component: Component<AnyObject>) => (props: AnyObject) 
 
     useLayoutEffect(() => {
         const dispose = UniwindListener.subscribe(rerender, Array.from(new Set(dependencies)), {
-            shouldNotifyVariables: (theme) => theme === (uniwindContext.scopedTheme ?? UniwindStore.runtime.currentThemeName),
+            shouldNotifyVariables: (theme) => theme === effectiveTheme,
         })
 
         return dispose
-    }, [dependencySum])
+    }, [dependencySum, effectiveTheme])
 
     return (
         <Component
@@ -90,6 +91,7 @@ const withAutoUniwind = (Component: Component<AnyObject>) => (props: AnyObject) 
 
 const withManualUniwind = (Component: Component<AnyObject>, options: Record<PropertyKey, OptionMapping>) => (props: AnyObject) => {
     const uniwindContext = useUniwindContext()
+    const effectiveTheme = uniwindContext.scopedTheme ?? UniwindStore.runtime.currentThemeName
     const { generatedProps, dependencies } = Object.entries(options).reduce((acc, [propName, option]) => {
         const className = props[option.fromClassName]
 
@@ -142,11 +144,11 @@ const withManualUniwind = (Component: Component<AnyObject>, options: Record<Prop
 
     useLayoutEffect(() => {
         const dispose = UniwindListener.subscribe(rerender, Array.from(new Set(dependencies)), {
-            shouldNotifyVariables: (theme) => theme === (uniwindContext.scopedTheme ?? UniwindStore.runtime.currentThemeName),
+            shouldNotifyVariables: (theme) => theme === effectiveTheme,
         })
 
         return dispose
-    }, [dependencySum])
+    }, [dependencySum, effectiveTheme])
 
     return (
         <Component

--- a/packages/uniwind/src/hooks/useCSSVariable/useCSSVariable.ts
+++ b/packages/uniwind/src/hooks/useCSSVariable/useCSSVariable.ts
@@ -1,4 +1,5 @@
 import { useLayoutEffect, useRef, useState } from 'react'
+import { Uniwind } from '../../core/config'
 import { useUniwindContext } from '../../core/context'
 import { UniwindListener } from '../../core/listener'
 import { Logger } from '../../core/logger'
@@ -71,6 +72,9 @@ export const useCSSVariable: UseCSSVariable = (name: string | Array<string>) => 
         const dispose = UniwindListener.subscribe(
             updateValue,
             [StyleDependency.Theme, StyleDependency.Variables],
+            {
+                shouldNotifyVariables: (theme) => theme === (uniwindContext.scopedTheme ?? Uniwind.currentTheme),
+            },
         )
 
         return dispose

--- a/packages/uniwind/src/hooks/useResolveClassNames.native.ts
+++ b/packages/uniwind/src/hooks/useResolveClassNames.native.ts
@@ -19,7 +19,9 @@ export const useResolveClassNames = (className: string) => {
 
     useLayoutEffect(() => {
         if (uniwindState.dependencies.length > 0) {
-            const dispose = UniwindListener.subscribe(recreate, uniwindState.dependencies)
+            const dispose = UniwindListener.subscribe(recreate, uniwindState.dependencies, {
+                shouldNotifyVariables: (theme) => theme === (uniwindContext.scopedTheme ?? UniwindStore.runtime.currentThemeName),
+            })
 
             return dispose
         }

--- a/packages/uniwind/src/hooks/useResolveClassNames.native.ts
+++ b/packages/uniwind/src/hooks/useResolveClassNames.native.ts
@@ -5,6 +5,7 @@ import { UniwindStore } from '../core/native'
 
 export const useResolveClassNames = (className: string) => {
     const uniwindContext = useUniwindContext()
+    const effectiveTheme = uniwindContext.scopedTheme ?? UniwindStore.runtime.currentThemeName
     const [uniwindState, recreate] = useReducer(
         () => UniwindStore.getStyles(className, undefined, undefined, uniwindContext),
         undefined,
@@ -20,12 +21,12 @@ export const useResolveClassNames = (className: string) => {
     useLayoutEffect(() => {
         if (uniwindState.dependencies.length > 0) {
             const dispose = UniwindListener.subscribe(recreate, uniwindState.dependencies, {
-                shouldNotifyVariables: (theme) => theme === (uniwindContext.scopedTheme ?? UniwindStore.runtime.currentThemeName),
+                shouldNotifyVariables: (theme) => theme === effectiveTheme,
             })
 
             return dispose
         }
-    }, [uniwindState.dependencySum, className])
+    }, [uniwindState.dependencySum, className, effectiveTheme])
 
     return uniwindState.styles
 }

--- a/packages/uniwind/tests/native/components/scoped-theme.test.tsx
+++ b/packages/uniwind/tests/native/components/scoped-theme.test.tsx
@@ -175,6 +175,47 @@ describe('ScopedTheme', () => {
         expect(nestedLightInDark).toHaveBeenLastCalledWith('#ffffff')
     })
 
+    test('useCSSVariable rerenders only affected custom scoped theme', () => {
+        const base = jest.fn()
+        const nestedCustom = jest.fn()
+
+        const Component = (props: { test: jest.Mock }) => {
+            const backgroundColor = useCSSVariable('--color-background')
+
+            props.test(backgroundColor)
+
+            return null
+        }
+
+        act(() => {
+            Uniwind.updateCSSVariables('custom', { '--color-background': '#123456' })
+        })
+
+        renderUniwind(
+            <React.Fragment>
+                <Component test={base} />
+                <ScopedTheme theme="custom">
+                    <Component test={nestedCustom} />
+                </ScopedTheme>
+            </React.Fragment>,
+        )
+
+        expect(Uniwind.currentTheme).toEqual('light')
+        expect(base).toHaveBeenCalledTimes(1)
+        expect(nestedCustom).toHaveBeenCalledTimes(1)
+        expect(base).toHaveBeenLastCalledWith('#ffffff')
+        expect(nestedCustom).toHaveBeenLastCalledWith('#123456')
+
+        act(() => {
+            Uniwind.updateCSSVariables('custom', { '--color-background': '#112233' })
+        })
+
+        expect(base).toHaveBeenCalledTimes(1)
+        expect(nestedCustom).toHaveBeenCalledTimes(2)
+        expect(base).toHaveBeenLastCalledWith('#ffffff')
+        expect(nestedCustom).toHaveBeenLastCalledWith('#112233')
+    })
+
     test('useUniwind', () => {
         const base = jest.fn()
         const nestedDark = jest.fn()

--- a/packages/uniwind/tests/setup.native.ts
+++ b/packages/uniwind/tests/setup.native.ts
@@ -15,13 +15,13 @@ beforeAll(async () => {
         cssPath,
         debug: true,
         platform: Platform.iOS,
-        themes: ['light', 'dark'],
+        themes: ['light', 'dark', 'custom'],
         polyfills: undefined,
     })
 
     eval(
         `const { Uniwind } = require('../src/core/config/config.native');
-        Uniwind.__reinit(rt => ${virtualCode}, ['light', 'dark']);
+        Uniwind.__reinit(rt => ${virtualCode}, ['light', 'dark', 'custom']);
             Uniwind.updateInsets({
             top: ${SAFE_AREA_INSET_TOP},
             left: 0,

--- a/packages/uniwind/tests/web/scoped-theme-css-variables.test.tsx
+++ b/packages/uniwind/tests/web/scoped-theme-css-variables.test.tsx
@@ -1,0 +1,58 @@
+import { act, render } from '@testing-library/react'
+import * as React from 'react'
+import { ScopedTheme } from '../../src/components/ScopedTheme/ScopedTheme'
+import { Uniwind } from '../../src/core/config/config'
+import { getWebVariable } from '../../src/core/web/getWebStyles'
+import { useCSSVariable } from '../../src/hooks/useCSSVariable'
+
+describe('Scoped theme + CSS variables (web)', () => {
+    afterEach(() => {
+        Uniwind.setTheme('light')
+        document.documentElement.removeAttribute('style')
+    })
+
+    test('getWebVariable reads runtime update for scoped theme while global theme stays light', () => {
+        Uniwind.setTheme('light')
+        Uniwind.updateCSSVariables('custom', { '--test-scoped-web-a': '#aabbcc' })
+
+        const value = getWebVariable('--test-scoped-web-a', { scopedTheme: 'custom' })
+
+        expect(value).toMatch(/^#aabbcc$/i)
+    })
+
+    test('useCSSVariable rerenders only affected custom scoped theme', () => {
+        const base = jest.fn()
+        const nestedScopedTestTheme = jest.fn()
+
+        const Component = (props: { test: jest.Mock }) => {
+            const v = useCSSVariable('--test-scoped-web-b')
+
+            props.test(v)
+
+            return null
+        }
+
+        Uniwind.setTheme('light')
+
+        render(
+            <React.Fragment>
+                <Component test={base} />
+                <ScopedTheme theme="custom">
+                    <Component test={nestedScopedTestTheme} />
+                </ScopedTheme>
+            </React.Fragment>,
+        )
+
+        expect(Uniwind.currentTheme).toEqual('light')
+        expect(base).toHaveBeenCalledTimes(1)
+        expect(nestedScopedTestTheme).toHaveBeenCalledTimes(1)
+
+        act(() => {
+            Uniwind.updateCSSVariables('custom', { '--test-scoped-web-b': '#ddeeff' })
+        })
+
+        expect(base).toHaveBeenCalledTimes(1)
+        expect(nestedScopedTestTheme).toHaveBeenCalledTimes(2)
+        expect(nestedScopedTestTheme.mock.calls[1][0]).toMatch(/^#ddeeff$/i)
+    })
+})


### PR DESCRIPTION
### Problem

`Uniwind.updateCSSVariables(theme, variables)` did not reliably trigger UI updates for components rendered under `<ScopedTheme>` when the updated `theme` differed from the globally active theme.

On web, runtime variable overrides for non-global themes were also not consistently observable via `getWebVariable` / `useCSSVariable`, because resolution depended on `document.documentElement` and computed styles without consulting per-theme runtime state.

### Solution

- Add a theme-scoped variable notification path so variable updates can target subscribers based on the subtree’s effective theme (`scopedTheme` when present, otherwise the global theme).
- On web, resolve `getWebVariable` against the per-theme runtime map for the effective theme before falling back to `getComputedStyle`.

### Testing

- Regression coverage for web and native scoped-theme variable updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSS variable updates are now theme-scoped: updates for a specific scoped theme only re-render components inside that scope, preventing unrelated rerenders and improving performance.
  * Runtime reads of CSS variables short-circuit to scoped runtime values when available, yielding consistent variable resolution.

* **Tests**
  * Added native and web tests covering scoped-theme CSS variable behavior and rerender correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->