### PR TITLE
fix: inject cjs instead of esm to initialize

### DIFF
--- a/packages/uniwind/src/metro/metro-transformer.ts
+++ b/packages/uniwind/src/metro/metro-transformer.ts
@@ -91,7 +91,7 @@ export const transform = async (
         isWeb
             ? virtualCode
             : [
-                `import { Uniwind } from '${name}';`,
+                `const { Uniwind } = require('${name}');`,
                 `Uniwind.__reinit(rt => ${virtualCode}, ${injectedThemesCode});`,
             ].join(''),
         'utf-8',


### PR DESCRIPTION
Fixes #500

In debug mode / without tree shaking metro was converting all files to CJS.
It doesn't do this in optimized, tree shaking build so it caused error.
Common JS is correct format on native

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mobile/TV CSS transformation build process for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->