### PR TITLE
fix: use node resolver to prevent escaped traversal errors

### DIFF
--- a/packages/uniwind/src/core/config/config.common.ts
+++ b/packages/uniwind/src/core/config/config.common.ts
@@ -101,7 +101,7 @@ export class UniwindConfigBuilder {
         // noop
     }
 
-    // oxlint-disable-next-line typescript/no-redundant-type-constituents
+    // oxlint-disable-next-line typescript/no-unused-vars
     updateInsets(insets: Insets) {
         // noop
     }

--- a/packages/uniwind/src/metro/resolvers.ts
+++ b/packages/uniwind/src/metro/resolvers.ts
@@ -1,5 +1,5 @@
 import { CustomResolutionContext, CustomResolver } from 'metro-resolver'
-import { basename, dirname, join, sep } from 'node:path'
+import { basename, dirname, sep } from 'node:path'
 
 type ResolverConfig = {
     platform: string | null
@@ -45,12 +45,11 @@ export const nativeResolver = ({
     const resolution = resolver(context, moduleName, platform)
 
     if (cachedInternalBasePath === null) {
-        const componentsResolution = resolver(context, 'uniwind/components', platform)
-
-        cachedInternalBasePath = componentsResolution.type === 'sourceFile'
-            // Go from src/components to root
-            ? join(dirname(componentsResolution.filePath), '../..')
-            : ''
+        try {
+            cachedInternalBasePath = dirname(require.resolve('uniwind/package.json'))
+        } catch {
+            cachedInternalBasePath = ''
+        }
     }
 
     const isInternal = cachedInternalBasePath !== '' && context.originModulePath.startsWith(cachedInternalBasePath)
@@ -94,13 +93,13 @@ export const webResolver = ({
     const resolution = resolver(context, moduleName, platform)
 
     if (cachedInternalBasePath === null) {
-        const componentsResolution = resolver(context, 'uniwind/components', platform)
-
-        cachedInternalBasePath = componentsResolution.type === 'sourceFile'
-            // Go from dist/module/components/web to root
-            ? join(dirname(componentsResolution.filePath), '../../../..')
-            : ''
+        try {
+            cachedInternalBasePath = dirname(require.resolve('uniwind/package.json'))
+        } catch {
+            cachedInternalBasePath = ''
+        }
     }
+
     if (
         (cachedInternalBasePath !== '' && context.originModulePath.startsWith(cachedInternalBasePath))
         || resolution.type !== 'sourceFile'


### PR DESCRIPTION
fixes #505 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal module resolution mechanism for improved reliability.
  * Updated internal linting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->