### PR TITLE
fix: remove deprecated push notification ios export

### DIFF
--- a/packages/uniwind/src/components/index.ts
+++ b/packages/uniwind/src/components/index.ts
@@ -196,9 +196,6 @@ module.exports = {
     get PlatformColor() {
         return require('react-native').PlatformColor
     },
-    get PushNotificationIOS() {
-        return require('react-native').PushNotificationIOS
-    },
     get processColor() {
         return require('react-native').processColor
     },


### PR DESCRIPTION
fixes #509 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `PushNotificationIOS` export from the components module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->