### PR TITLE
fix: atomic-write generated CSS to fix multi-worker race (#341)

### DIFF
--- a/packages/uniwind/src/css/index.ts
+++ b/packages/uniwind/src/css/index.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { atomicWriteFileSync } from '../utils/atomicWriteFileSync'
 import { EXTRA_UTILITIES_CSS } from './extraUtilities'
 import { INSETS_CSS } from './insets'
 import { OVERWRITE_CSS } from './overwrite'
@@ -27,8 +28,5 @@ export const buildCSS = async (themes: Array<string>, input: string) => {
         return
     }
 
-    fs.writeFileSync(
-        cssFilePath,
-        newCssFile,
-    )
+    atomicWriteFileSync(cssFilePath, newCssFile)
 }

--- a/packages/uniwind/src/utils/atomicWriteFileSync.ts
+++ b/packages/uniwind/src/utils/atomicWriteFileSync.ts
@@ -1,0 +1,22 @@
+import crypto from 'crypto'
+import fs from 'fs'
+
+/**
+ * Write a file by staging to a temp path in the same directory and renaming
+ * onto the target. `rename` is atomic on POSIX and Windows, so concurrent
+ * readers always observe either the previous file or the complete new file —
+ * never a partial write. See https://github.com/uni-stack/uniwind/issues/341.
+ */
+export const atomicWriteFileSync = (filePath: string, content: string) => {
+    const tmpPath = `${filePath}.${crypto.randomUUID()}.tmp`
+    fs.writeFileSync(tmpPath, content)
+    try {
+        fs.renameSync(tmpPath, filePath)
+    } catch (err) {
+        // best-effort cleanup
+        try {
+            fs.unlinkSync(tmpPath)
+        } catch {}
+        throw err
+    }
+}

--- a/packages/uniwind/src/utils/buildDtsFile.ts
+++ b/packages/uniwind/src/utils/buildDtsFile.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import { name } from '../../package.json'
+import { atomicWriteFileSync } from './atomicWriteFileSync'
 
 export const buildDtsFile = (dtsPath: string, stringifiedThemes: string) => {
     const oldDtsContent = fs.existsSync(dtsPath)
@@ -23,5 +24,5 @@ export const buildDtsFile = (dtsPath: string, stringifiedThemes: string) => {
         return
     }
 
-    fs.writeFileSync(dtsPath, dtsContent)
+    atomicWriteFileSync(dtsPath, dtsContent)
 }


### PR DESCRIPTION
## Problem

`buildCSS` writes `node_modules/uniwind/uniwind.css` via `fs.writeFileSync` from every transform of `components/web/metro-injected.js` and the CSS entry file. Metro spawns multiple worker processes, so those calls fire concurrently. `writeFileSync` truncates-then-writes, so when one worker is mid-write, another worker can observe a partial file as Tailwind compiles `@import 'uniwind'` from `generateCSSForThemes` / `compileVirtual`. The partial read fails to parse and surfaces as the cryptic error reported in #341:

```
SyntaxError: .../uniwind/dist/{common,module}/components/web/metro-injected.js:
  Missing closing } at &:not(:where(.light, .light *, .dark, .dark *, ...))
```

This reproduces on Linux CI (concurrent workers, low-overhead scheduling) and is effectively invisible on macOS. Enabling `EXPO_UNSTABLE_TREE_SHAKING=1` adds enough transforms to surface it consistently. A previous reporter on #341 ([zlanich](https://github.com/uni-stack/uniwind/issues/341#issuecomment-3866503573)) traced the same root cause and worked around it by pre-generating `uniwind.css` in a single process before `expo export` runs.

## Fix

Route both `buildCSS` and `buildDtsFile` through a new `atomicWriteFileSync` helper that stages to a unique temp file in the same directory and renames onto the target. POSIX `rename` is atomic; Windows' `MoveFileEx` (which Node's `fs.renameSync` uses on Win32) does atomic replace too. Concurrent readers always observe either the previous file or the complete new file — never a torn write.

## Reproduction

Without a clean isolated repro we can share publicly (it requires concurrent Metro workers and a sufficiently large theme set to make the partial-read window observable), the symptoms in #341 and downstream reports are consistent across at least three users and the code clearly has the race the fix addresses. Applying this patch via `patch-package` on a downstream project that hit the bug under `EXPO_UNSTABLE_TREE_SHAKING=1` made the bundle deterministic across many CI runs.

[I failed to reproduce the issue in https://github.com/williamrobertson13/uniwind-issue-341-repro]

## Checks

- `bun run check:typescript` ✅
- `bun run lint` ✅
- `bun run check:format` ✅
- `bun run circular:check` ✅
- `bun run build` ✅
- `bun run test:native` ✅ (107 tests)
- `bun run test:web` ✅ (12 tests)
- `bun run test:types` ✅

Refs: #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved file-generation paths to use atomic write operations, reducing risk of partial or interrupted writes and avoiding unnecessary rewrites when content is unchanged.
* **New Feature**
  * Added an atomic file-write utility used by generation processes to ensure safer, more reliable output file updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uni-stack/uniwind/pull/532)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->