### PR TITLE
Fix !important modifier having no effect on native

### DIFF
--- a/packages/uniwind/src/metro/addMetaToStylesTemplate.ts
+++ b/packages/uniwind/src/metro/addMetaToStylesTemplate.ts
@@ -126,7 +126,7 @@ export const addMetaToStylesTemplate = (Processor: ProcessorBuilder, currentPlat
                     focus,
                     disabled,
                     importantProperties: importantProperties
-                        ?.map(property => property.startsWith('--') ? property : toCamelCase)
+                        ?.map(property => property.startsWith('--') ? property : toCamelCase(property))
                         .map(makeSafeForSerialization) ?? [],
                     dataAttributes,
                     complexity: [

--- a/packages/uniwind/tests/native/styles-parsing/specificity.test.tsx
+++ b/packages/uniwind/tests/native/styles-parsing/specificity.test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+import View from '../../../src/components/native/View'
+import { TW_BLUE_500, TW_GREEN_500, TW_RED_500 } from '../../consts'
+import { renderUniwind } from '../utils'
+
+describe('Specificity', () => {
+    test('Important', () => {
+        const { getStylesFromId } = renderUniwind(
+            <React.Fragment>
+                <View
+                    className="text-red-500 text-blue-500"
+                    testID="no-important"
+                />
+                <View
+                    className="text-red-500! text-blue-500!"
+                    testID="both-important"
+                />
+                <View
+                    className="text-red-500! text-green-500 text-blue-500"
+                    testID="important-first"
+                />
+                <View
+                    className="text-red-500 text-green-500! text-blue-500"
+                    testID="important-middle"
+                />
+                <View
+                    className="text-red-500 text-green-500 text-blue-500!"
+                    testID="important-last"
+                />
+            </React.Fragment>,
+        )
+
+        expect(getStylesFromId('no-important').color).toBe(TW_BLUE_500)
+        /* NOTE: when both classes are !important, the first one wins.
+        This diverges from CSS where the last !important would win. */
+        expect(getStylesFromId('both-important').color).toBe(TW_RED_500)
+        expect(getStylesFromId('important-first').color).toBe(TW_RED_500)
+        expect(getStylesFromId('important-middle').color).toBe(TW_GREEN_500)
+        expect(getStylesFromId('important-last').color).toBe(TW_BLUE_500)
+    })
+})


### PR DESCRIPTION
### Problem

The Tailwind `!important` modifier (e.g., `text-red-500!`) has no effect
on native platforms. Classes without the modifier always win regardless
of the `!` flag.

### Root cause

In `addMetaToStylesTemplate.ts`, `toCamelCase` is passed as a value
instead of being called as a function when mapping `importantProperties`:

```ts
// Before (broken) — passes the function reference itself
importantProperties: importantProperties
    ?.map(property => property.startsWith('--') ? property : toCamelCase)
```

This means the `importantProperties` array ends up containing the
`toCamelCase` function reference instead of the camelCased property name
string (e.g., `"color"`).

At runtime, the store checks:

```ts
previousBest.importantProperties.includes(property)
```

This compares a string like `"color"` against an array containing a
function reference, so it never matches and the `!important` guard
silently fails.

### Fix

```ts
// After (fixed) — calls the function with the property
importantProperties: importantProperties
    ?.map(property => property.startsWith('--') ? property : toCamelCase(property))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected style property name conversion to ensure proper serialization and consistent styling behavior.

* **Tests**
  * Added a specificity test suite to verify style conflict resolution, including handling of important rules and deterministic tie-breaking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uni-stack/uniwind/pull/534)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->