### PR TITLE
feat: public generate-artifacts script

### DIFF
--- a/packages/uniwind/build.config.ts
+++ b/packages/uniwind/build.config.ts
@@ -65,6 +65,11 @@ export default defineBuildConfig({
             name: 'vite/index',
         },
         {
+            builder: 'rollup',
+            input: './src/bundler/cli/index.ts',
+            name: 'cli/index',
+        },
+        {
             builder: 'mkdist',
             input: './src/bundler/adapters/vite',
             outDir: 'dist/vite',

--- a/packages/uniwind/package.json
+++ b/packages/uniwind/package.json
@@ -6,6 +6,9 @@
     "homepage": "https://uniwind.dev",
     "author": "Unistack",
     "type": "module",
+    "bin": {
+        "uniwind": "./dist/cli/index.mjs"
+    },
     "repository": "https://github.com/uni-stack/uniwind",
     "sideEffects": false,
     "scripts": {

--- a/packages/uniwind/src/bundler/cli/index.ts
+++ b/packages/uniwind/src/bundler/cli/index.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { UniwindBundlerConfig } from '@/bundler/config'
+import { Logger } from '@/bundler/logger'
+import path from 'path'
+
+const dirname = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname
+const cssArtifactPath = path.resolve(dirname, '../../uniwind.css')
+
+type GenerateArtifactsArgs = {
+    cssEntryFile?: string
+    dtsFile?: string
+    extraThemes: Array<string>
+}
+
+const printHelp = () => {
+    console.log([
+        'Usage: uniwind generate-artifacts --css <file> [--theme <name>...] [--dts <file>]',
+        '',
+        'Options:',
+        '  --css <file>      CSS entry file path, e.g. ./global.css',
+        '  --theme <name>    Extra theme name. Can be passed multiple times',
+        '  --dts <file>      Generated TypeScript declarations path',
+        '  --help            Show help',
+    ].join('\n'))
+}
+
+const readValue = (args: Array<string>, index: number, flag: string) => {
+    const value = args[index + 1]
+
+    if (value === undefined || value.startsWith('--')) {
+        throw new Error(`Uniwind: ${flag} requires a value`)
+    }
+
+    return value
+}
+
+const parseGenerateArtifactsArgs = (args: Array<string>): GenerateArtifactsArgs => {
+    const parsed: GenerateArtifactsArgs = {
+        extraThemes: [],
+    }
+
+    for (let index = 0; index < args.length; index++) {
+        const arg = args[index]
+
+        switch (arg) {
+            case '--css':
+                parsed.cssEntryFile = readValue(args, index, arg)
+                index++
+                break
+            case '--theme':
+                parsed.extraThemes.push(readValue(args, index, arg))
+                index++
+                break
+            case '--dts':
+                parsed.dtsFile = readValue(args, index, arg)
+                index++
+                break
+            case '--help':
+                printHelp()
+                process.exit(0)
+            default:
+                throw new Error(`Uniwind: Unknown option ${arg}`)
+        }
+    }
+
+    return parsed
+}
+
+const generateArtifacts = async (args: Array<string>) => {
+    const parsed = parseGenerateArtifactsArgs(args)
+    const bundlerConfig = UniwindBundlerConfig.fromCliConfig({
+        cssEntryFile: parsed.cssEntryFile!,
+        dtsFile: parsed.dtsFile,
+        extraThemes: parsed.extraThemes,
+    })
+
+    await bundlerConfig.generateArtifacts(cssArtifactPath)
+    Logger.info('Artifacts generated')
+}
+
+const main = async () => {
+    const [command, ...args] = process.argv.slice(2)
+
+    if (command === '--help' || command === undefined) {
+        printHelp()
+
+        return
+    }
+
+    switch (command) {
+        case 'generate-artifacts':
+            await generateArtifacts(args)
+
+            break
+        default:
+            throw new Error(`Uniwind: Unknown command ${command}`)
+    }
+}
+
+main().catch(error => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+})

--- a/packages/uniwind/src/bundler/cli/index.ts
+++ b/packages/uniwind/src/bundler/cli/index.ts
@@ -2,9 +2,10 @@
 
 import { UniwindBundlerConfig } from '@/bundler/config'
 import { Logger } from '@/bundler/logger'
+import { fileURLToPath } from 'node:url'
 import path from 'path'
 
-const dirname = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname
+const dirname = path.dirname(fileURLToPath(import.meta.url))
 const cssArtifactPath = path.resolve(dirname, '../../uniwind.css')
 
 type GenerateArtifactsArgs = {

--- a/packages/uniwind/src/bundler/config.ts
+++ b/packages/uniwind/src/bundler/config.ts
@@ -45,6 +45,16 @@ export class UniwindBundlerConfig {
         return new UniwindBundlerConfig(config, Platform.Web)
     }
 
+    static fromCliConfig(config: UniwindConfig) {
+        if (typeof config.cssEntryFile === 'undefined') {
+            throw new Error(
+                'Uniwind: You need to pass css entry file, e.g. uniwind generate-artifacts --css ./global.css. Run uniwind generate-artifacts --help for usage.',
+            )
+        }
+
+        return new UniwindBundlerConfig(config, Platform.Web)
+    }
+
     constructor(private readonly config: UniwindMetroConfig, readonly platform: Platform) {}
 
     get cssPath() {

--- a/packages/uniwind/src/bundler/logger.ts
+++ b/packages/uniwind/src/bundler/logger.ts
@@ -16,6 +16,10 @@ export class Logger {
         console.log(`${blue}Uniwind ${meta}- ${message}${reset}`)
     }
 
+    static info(message: string) {
+        console.log(`${blue}[Uniwind] ${message}${reset}`)
+    }
+
     static error(message: string, meta = '') {
         console.log(`${red}Uniwind Error ${meta}- ${message}${reset}`)
     }


### PR DESCRIPTION
Fixes #544 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a command-line interface: run `uniwind generate-artifacts` to generate build artifacts with options for CSS file, repeated themes, optional TypeScript declarations, and built-in help.
  * Installs a runnable CLI executable for direct use.
  * Improves CLI output with clearer informational messages and user-friendly error reporting and exit behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uni-stack/uniwind/pull/550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->