### PR TITLE
fix(metro): pin uniwind to a single copy in withUniwindConfig

### DIFF
--- a/packages/uniwind/src/bundler/adapters/metro/metro.ts
+++ b/packages/uniwind/src/bundler/adapters/metro/metro.ts
@@ -1,9 +1,14 @@
+import { resolve } from 'node:path'
+
 import { UniwindBundlerConfig } from '@/bundler/config'
-import type { UniwindConfig } from '@/bundler/types'
 import { Platform } from '@/common/consts'
-import type { MetroConfig } from 'metro-config'
+
 import { cacheStore, patchMetroGraphToSupportUncachedModules } from './patches'
 import { nativeResolver, webResolver } from './resolvers'
+
+import type { UniwindConfig } from '@/bundler/types'
+import type { MetroConfig } from 'metro-config'
+import type { CustomResolver } from 'metro-resolver'
 
 export const withUniwindConfig = <T extends MetroConfig>(
     config: T,
@@ -22,15 +27,25 @@ export const withUniwindConfig = <T extends MetroConfig>(
         },
         resolver: {
             ...config.resolver,
-            sourceExts: [
-                ...config.resolver?.sourceExts ?? [],
-                'css',
-            ],
-            assetExts: config.resolver?.assetExts?.filter(
-                ext => ext !== 'css',
-            ),
+            sourceExts: [...(config.resolver?.sourceExts ?? []), 'css'],
+            assetExts: config.resolver?.assetExts?.filter((ext) => ext !== 'css'),
             resolveRequest: (context, moduleName, platform) => {
-                const resolver = config.resolver?.resolveRequest ?? context.resolveRequest
+                const baseResolver = config.resolver?.resolveRequest ?? context.resolveRequest
+                // Pin every `uniwind` specifier to a single physical copy. In monorepos
+                // (bun/pnpm) uniwind can be installed as multiple peer-hash copies; mixing
+                // them both crashes Hermes ("Maximum call stack size exceeded" via
+                // get NativeModules recursion, when the react-native shim redirects across
+                // copies) and splits uniwind's theme runtime across instances (no styling,
+                // colorKit "invalid" color errors). Resolving every `uniwind` request from
+                // a single origin (the project root) collapses them to one instance.
+                // Wrapping `resolver` — not just this resolveRequest — ensures the platform
+                // resolvers' internal `react-native` -> `uniwind/components` redirects are
+                // pinned too.
+                const pinnedOrigin = resolve(config.projectRoot ?? process.cwd(), 'index.js')
+                const resolver: CustomResolver = (ctx, name, plat) =>
+                    name.split('/')[0] === 'uniwind' && ctx.originModulePath !== pinnedOrigin
+                        ? baseResolver({ ...ctx, originModulePath: pinnedOrigin }, name, plat)
+                        : baseResolver(ctx, name, plat)
                 const platformResolver = platform === Platform.Web ? webResolver : nativeResolver
                 const resolved = platformResolver({
                     context,


### PR DESCRIPTION
## Problem

In monorepos using bun or pnpm, `uniwind` can be installed as **multiple physical copies** (different peer-hash variants in bun's store, or duplicate copies under pnpm). When more than one copy ends up reachable by Metro, there are two failure modes:

1. **Hermes crash at startup** — `RangeError: Maximum call stack size exceeded (native stack depth)`, a `get NativeModules` recursion. uniwind's metro plugin rewrites `import 'react-native'` → `uniwind/components`. The `isInternal` guard (keyed to `require.resolve('uniwind/package.json')`) is meant to let uniwind's *own* `require('react-native')` reach real RN — but when Metro resolves a uniwind file to a *different* copy than the one that seeded the guard, `isInternal` is `false` for code that genuinely is internal, so the shim redirects its own `require('react-native')` back into `uniwind/components` and recurses forever.

2. **Silently broken styling** — when it doesn't crash outright, the two copies split uniwind's theme/CSS runtime across instances: components render from one copy while the theme initialized in the other. Result is no styling plus `[colorKit.RGB] … "invalid" is not a valid color or brush` warnings.

This is install-order dependent (the crash happens only when an app's canonical copy differs from the copy Metro's hierarchical lookup falls back to), which makes it hard to reproduce on demand.

Tracked in #353. Minimal deterministic repro: https://github.com/ottob/uniwind-353-repro (`bun install && bun run diagnose` shows the two copies and predicts the crash).

## Fix

Pin every `uniwind` specifier to a single physical copy by resolving it from one stable origin (the Metro `projectRoot`). The key detail: wrap the **`resolver`** that's passed into `nativeResolver`/`webResolver`, not just the outer `resolveRequest` — the platform resolvers perform the internal `react-native` → `uniwind/components` redirect through that inner `resolver`, and that's exactly where the recursion forms.

```ts
const baseResolver = config.resolver?.resolveRequest ?? context.resolveRequest
const pinnedOrigin = resolve(config.projectRoot ?? process.cwd(), 'index.js')
const resolver: CustomResolver = (ctx, name, plat) =>
  name.split('/')[0] === 'uniwind' && ctx.originModulePath !== pinnedOrigin
    ? baseResolver({ ...ctx, originModulePath: pinnedOrigin }, name, plat)
    : baseResolver(ctx, name, plat)
```

This collapses duplicate copies to one instance, fixing both the recursion and the split-runtime styling bug. Non-`uniwind` specifiers (including `react-native`) are untouched, so the existing react-native → components shim for app code behaves exactly as before.

## Notes / scope for discussion

- Pins only bare `uniwind` / `uniwind/*` specifiers; everything else is passed through unchanged.
- `config.projectRoot` from `getDefaultConfig` is relative (`"."`), so `path.resolve` (not `join`) is used to produce an absolute origin.
- Alternative considered: hardening only the `isInternal` guard to recognize any `…/uniwind/(dist|src)/…` origin. That stops the *crash* but **not** the split-runtime styling bug, because the duplication is in how Metro resolves `import { Text } from 'uniwind'` per-origin — only single-copy resolution fixes both. Hence pinning here.

## Verification

- `check:typescript`, `lint`, `dprint fmt`, and `build` all pass.
- Validated end-to-end in a real bun monorepo (Expo SDK 56, RN 0.85, new arch) that previously crashed with the `get NativeModules` recursion: with this change the app boots and styling renders correctly, with no per-app `metro.config.js` workaround.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Metro bundler's CSS source file resolution by properly extending recognized source extensions.
  * Improved module resolution consistency by ensuring Uniwind package imports are correctly pinned to their intended physical locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->