### PR TITLE
test: failing tests — inline direction from ancestor is ignored by rtl:/ltr: variants

### DIFF
--- a/packages/uniwind/tests/native/styles-parsing/dir.test.tsx
+++ b/packages/uniwind/tests/native/styles-parsing/dir.test.tsx
@@ -62,4 +62,28 @@ describe('Dir', () => {
 
         expect(getStylesFromId('ltr-red').backgroundColor).toBe(TW_RED_500)
     })
+
+    test('inline RTL inherited from ancestor', () => {
+        mockRTL(false)
+
+        const { getStylesFromId } = renderUniwind(
+            <View style={{ direction: 'rtl' }}>
+                <View className="rtl:bg-red-500 bg-blue-500" testID="rtl-red" />
+            </View>,
+        )
+
+        expect(getStylesFromId('rtl-red').backgroundColor).toBe(TW_RED_500)
+    })
+
+    test('inline LTR inherited from ancestor', () => {
+        mockRTL(true)
+
+        const { getStylesFromId } = renderUniwind(
+            <View style={{ direction: 'ltr' }}>
+                <View className="ltr:bg-red-500 bg-blue-500" testID="ltr-red" />
+            </View>,
+        )
+
+        expect(getStylesFromId('ltr-red').backgroundColor).toBe(TW_RED_500)
+    })
 })


### PR DESCRIPTION
Failing tests showing that `rtl:`/`ltr:` variants ignore `direction` set on an ancestor (`validateDir` only checks the component's own `props.style`).

Follow-up to https://github.com/uni-stack/uniwind/pull/574#issuecomment-4669557231 — proves https://github.com/uni-stack/uniwind/issues/573 is not fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for directional styling inheritance, verifying that direction-specific utility classes are properly resolved when inherited from parent elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->