### PR TITLE
ci: close issues on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,7 +112,7 @@ jobs:
           RELEASE_URL="$(gh release view "$TAG" --json url --jq .url)"
 
           gh issue list --state open --label "pending-release" --json number --jq '.[].number' | while read -r ISSUE; do
-            gh issue edit "$ISSUE" --remove-label "pending-release"
-            gh issue comment "$ISSUE" --body "New release $TAG is published: $RELEASE_URL"
-            gh issue close "$ISSUE"
+            gh issue edit "$ISSUE" --remove-label "pending-release" || echo "::warning::failed to remove label on #$ISSUE"
+            gh issue comment "$ISSUE" --body "New release $TAG is published: $RELEASE_URL" || echo "::warning::failed to comment on #$ISSUE"
+            gh issue close "$ISSUE" || echo "::warning::failed to close #$ISSUE"
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,3 +100,19 @@ jobs:
           npx release-it $ARGS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Close pending release issues
+        if: ${{ inputs.dry_run == false }}
+        working-directory: packages/uniwind
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          TAG="v$VERSION"
+          RELEASE_URL="$(gh release view "$TAG" --json url --jq .url)"
+
+          gh issue list --state open --label "pending-release" --json number --jq '.[].number' | while read -r ISSUE; do
+            gh issue edit "$ISSUE" --remove-label "pending-release"
+            gh issue comment "$ISSUE" --body "New release $TAG is published: $RELEASE_URL"
+            gh issue close "$ISSUE"
+          done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated cleanup after releases now closes any open “pending release” issues once a release is published.
  * Adds a release notice to each matched issue with the new version and release link.
  * Skips this cleanup step during dry runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->