### PR TITLE
fix: Remove reference to Touchable in package types

### DIFF
--- a/packages/uniwind/types.d.ts
+++ b/packages/uniwind/types.d.ts
@@ -1,13 +1,10 @@
 import {
-    ScrollViewProps,
-    ScrollViewPropsAndroid,
-    ScrollViewPropsIOS,
-    Touchable,
+    ScrollViewProps as ScrollViewPropsBase,
     VirtualizedListProps,
 } from 'react-native'
 
 declare module '@react-native/virtualized-lists' {
-    export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollViewProps {
+    export interface VirtualizedListWithoutRenderItemProps<ItemT> extends ScrollViewPropsBase {
         ListFooterComponentClassName?: string
         ListHeaderComponentClassName?: string
     }
@@ -37,7 +34,7 @@ declare module 'react-native' {
         contentContainerClassName?: string
     }
 
-    interface ScrollViewProps extends ViewProps, ScrollViewPropsIOS, ScrollViewPropsAndroid, Touchable {
+    interface ScrollViewProps extends ViewProps, ScrollViewPropsBase {
         contentContainerClassName?: string
         endFillColorClassName?: string
     }


### PR DESCRIPTION
**Motivation**

Align Uniwind with modern/real types from the `react-native` package. This is a load bearing breakage for users under React Native's [Strict TypeScript API](https://reactnative.dev/docs/strict-typescript-api) and we are likely removing this export in React Native 0.87. 

**Problem**

We found a load bearing call site in Uniwind where the `Touchable` type is imported from `react-native` and used for the `ScrollViewProps` type augmentation.

https://github.com/uni-stack/uniwind/blob/6b498f2ada673d2b92915c79a703286078b953c2/packages/uniwind/types.d.ts#L1-L7

https://github.com/uni-stack/uniwind/blob/6b498f2ada673d2b92915c79a703286078b953c2/packages/uniwind/types.d.ts#L40

There are two issues with this:
- The `Touchable` type shouldn't really exist in core (see below).
- Extending this type is redundant, as `onTouchStart` etc are already present on `ViewProps`.

**Fix**

Simplify `types.d.ts` to factor out `Touchable`. No type shape / functional changes.

---

**Mini-dive: This was a nonsense type(!)**

`Touchable` today is a manually maintained TypeScript definition shadowing a runtime object that has no overlap.

Current (manual) TS definition:

<img width="801" height="157" alt="image" src="https://github.com/user-attachments/assets/6c4ed0c6-a2e4-4b11-956c-d839f14c6e4b" />

https://github.com/react/react-native/blob/a7959ddc983855cc40390d637aadbfb213e7c3a7/packages/react-native/Libraries/Components/Touchable/Touchable.d.ts#L18-L24

vs the real object with two props — an internal implementation object with `Mixin` and `renderDebugView`:

<img width="795" height="127" alt="image" src="https://github.com/user-attachments/assets/0b9f5aff-4d1f-4085-97bf-2fd6b76284f0" />

https://github.com/react/react-native/blob/a7959ddc983855cc40390d637aadbfb213e7c3a7/packages/react-native/Libraries/Components/Touchable/Touchable.js#L966-L971

We're actually going to pursue **removing this**, which may land in RN 0.87.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Updated React Native type definitions to use a shared base for scroll-related props.
  * Improved consistency in supported props across list and scroll components, reducing TypeScript type mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->