### PR TITLE
Add an internal Expo-project marker to the Uniwind Metro config and use it to lazily choose the correct transform worker.

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,6 +113,7 @@ Metro integration:
 - `withUniwindConfig(config, uniwindConfig)` patches Metro graph support for uncached modules.
 - Metro adds `css` as source extension and removes it from asset extensions.
 - Metro transformer handles the configured CSS entry file specially.
+- Metro transformer worker selection is lazy and follows whether the incoming Metro config uses Expo's transformer path.
 - Native platform CSS transforms into a JS module that calls `Uniwind.__reinit(...)`.
 - Web platform CSS transforms into CSS plus web runtime setup.
 - Resolver swaps React Native component imports to Uniwind-aware implementations where needed.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,7 +113,7 @@ Metro integration:
 - `withUniwindConfig(config, uniwindConfig)` patches Metro graph support for uncached modules.
 - Metro adds `css` as source extension and removes it from asset extensions.
 - Metro transformer handles the configured CSS entry file specially.
-- Metro transformer worker selection is lazy and follows whether the incoming Metro config uses Expo's transformer path.
+- Metro transformer worker selection is lazy, cached per Expo/non-Expo config type, and follows Expo transformer paths or Expo-specific config markers.
 - Native platform CSS transforms into a JS module that calls `Uniwind.__reinit(...)`.
 - Web platform CSS transforms into CSS plus web runtime setup.
 - Resolver swaps React Native component imports to Uniwind-aware implementations where needed.

--- a/packages/uniwind/src/bundler/adapters/metro/metro.ts
+++ b/packages/uniwind/src/bundler/adapters/metro/metro.ts
@@ -9,6 +9,29 @@ import { nativeResolver, webResolver } from './resolvers'
 
 const isUniwindRequest = (moduleName: string) => moduleName === 'uniwind' || moduleName.startsWith('uniwind/')
 
+type ExpoTransformerConfig = NonNullable<MetroConfig['transformer']> & {
+    _expoRelativeProjectRoot?: string
+    _expoRouterPath?: string
+    expo_customTransformerPath?: string | false
+    postcssHash?: string | null
+}
+
+const isExpoMetroConfig = (config: MetroConfig) => {
+    const transformerPath = config.transformerPath
+    const transformer = config.transformer as ExpoTransformerConfig | undefined
+    const hasExpoTransformerField = transformer
+        ? '_expoRelativeProjectRoot' in transformer
+            || '_expoRouterPath' in transformer
+            || 'expo_customTransformerPath' in transformer
+            || 'postcssHash' in transformer
+        : false
+
+    return Boolean(
+        transformerPath?.includes('@expo/metro-config')
+            || hasExpoTransformerField,
+    )
+}
+
 export const withUniwindConfig = <T extends MetroConfig>(
     config: T,
     uniwindConfig: UniwindConfig,
@@ -26,7 +49,7 @@ export const withUniwindConfig = <T extends MetroConfig>(
             ...config.transformer,
             uniwind: {
                 ...bundlerConfig.toMetroConfig(),
-                isExpoProject: config.transformerPath?.includes('@expo/metro-config'),
+                isExpoProject: isExpoMetroConfig(config),
             },
         },
         resolver: {

--- a/packages/uniwind/src/bundler/adapters/metro/metro.ts
+++ b/packages/uniwind/src/bundler/adapters/metro/metro.ts
@@ -9,22 +9,11 @@ import { nativeResolver, webResolver } from './resolvers'
 
 const isUniwindRequest = (moduleName: string) => moduleName === 'uniwind' || moduleName.startsWith('uniwind/')
 
-type ExpoTransformerConfig = NonNullable<MetroConfig['transformer']> & {
-    _expoRelativeProjectRoot?: string
-    _expoRouterPath?: string
-    expo_customTransformerPath?: string | false
-    postcssHash?: string | null
-}
-
 const isExpoMetroConfig = (config: MetroConfig) => {
     const transformerPath = config.transformerPath
-    const transformer = config.transformer as ExpoTransformerConfig | undefined
-    const hasExpoTransformerField = transformer
-        ? '_expoRelativeProjectRoot' in transformer
-            || '_expoRouterPath' in transformer
-            || 'expo_customTransformerPath' in transformer
-            || 'postcssHash' in transformer
-        : false
+    const hasExpoTransformerField = Object.keys(config.transformer ?? {}).some(
+        key => key.startsWith('expo') || key.startsWith('_expo'),
+    )
 
     return Boolean(
         transformerPath?.includes('@expo/metro-config')
@@ -47,10 +36,7 @@ export const withUniwindConfig = <T extends MetroConfig>(
         transformerPath: require.resolve('./transformer.cjs'),
         transformer: {
             ...config.transformer,
-            uniwind: {
-                ...bundlerConfig.toMetroConfig(),
-                isExpoProject: isExpoMetroConfig(config),
-            },
+            uniwind: bundlerConfig.toMetroConfig(isExpoMetroConfig(config)),
         },
         resolver: {
             ...config.resolver,

--- a/packages/uniwind/src/bundler/adapters/metro/metro.ts
+++ b/packages/uniwind/src/bundler/adapters/metro/metro.ts
@@ -24,7 +24,10 @@ export const withUniwindConfig = <T extends MetroConfig>(
         transformerPath: require.resolve('./transformer.cjs'),
         transformer: {
             ...config.transformer,
-            uniwind: bundlerConfig.toMetroConfig(),
+            uniwind: {
+                ...bundlerConfig.toMetroConfig(),
+                isExpoProject: config.transformerPath?.includes('@expo/metro-config'),
+            },
         },
         resolver: {
             ...config.resolver,

--- a/packages/uniwind/src/bundler/adapters/metro/transformer.ts
+++ b/packages/uniwind/src/bundler/adapters/metro/transformer.ts
@@ -9,6 +9,7 @@ import path from 'path'
 
 const cssArtifactPath = path.resolve(__dirname, '../../uniwind.css')
 
+// Cache workers separately for Expo (`true`) and plain Metro (`false`) configs.
 const workerCache = new Map<boolean, typeof MetroTransformWorker>()
 
 const getTransformWorker = (isExpoProject?: boolean): typeof MetroTransformWorker => {

--- a/packages/uniwind/src/bundler/adapters/metro/transformer.ts
+++ b/packages/uniwind/src/bundler/adapters/metro/transformer.ts
@@ -9,14 +9,17 @@ import path from 'path'
 
 const cssArtifactPath = path.resolve(__dirname, '../../uniwind.css')
 
-let worker: typeof MetroTransformWorker | undefined
+const workerCache = new Map<boolean, typeof MetroTransformWorker>()
 
 const getTransformWorker = (isExpoProject?: boolean): typeof MetroTransformWorker => {
-    if (worker) {
-        return worker
+    const cacheKey = Boolean(isExpoProject)
+    const cachedWorker = workerCache.get(cacheKey)
+
+    if (cachedWorker) {
+        return cachedWorker
     }
 
-    const resolvedWorker: typeof MetroTransformWorker = isExpoProject
+    const resolvedWorker: typeof MetroTransformWorker = cacheKey
         ? (() => {
             try {
                 const { unstable_transformerPath } = require('@expo/metro-config') as typeof ExpoMetroConfig
@@ -28,7 +31,7 @@ const getTransformWorker = (isExpoProject?: boolean): typeof MetroTransformWorke
         })()
         : require('metro-transform-worker')
 
-    worker = resolvedWorker
+    workerCache.set(cacheKey, resolvedWorker)
 
     return resolvedWorker
 }

--- a/packages/uniwind/src/bundler/adapters/metro/transformer.ts
+++ b/packages/uniwind/src/bundler/adapters/metro/transformer.ts
@@ -9,18 +9,28 @@ import path from 'path'
 
 const cssArtifactPath = path.resolve(__dirname, '../../uniwind.css')
 
-let worker: typeof MetroTransformWorker
+let worker: typeof MetroTransformWorker | undefined
 
-try {
-    try {
-        const { unstable_transformerPath } = require('@expo/metro-config') as typeof ExpoMetroConfig
-
-        worker = require(unstable_transformerPath)
-    } catch {
-        worker = require('@expo/metro-config/build/transform-worker/transform-worker.js')
+const getTransformWorker = (isExpoProject?: boolean): typeof MetroTransformWorker => {
+    if (worker) {
+        return worker
     }
-} catch {
-    worker = require('metro-transform-worker')
+
+    const resolvedWorker: typeof MetroTransformWorker = isExpoProject
+        ? (() => {
+            try {
+                const { unstable_transformerPath } = require('@expo/metro-config') as typeof ExpoMetroConfig
+
+                return require(unstable_transformerPath)
+            } catch {
+                return require('@expo/metro-config/build/transform-worker/transform-worker.js')
+            }
+        })()
+        : require('metro-transform-worker')
+
+    worker = resolvedWorker
+
+    return resolvedWorker
 }
 
 export const transform = async (
@@ -32,6 +42,7 @@ export const transform = async (
     data: Buffer,
     options: JsTransformOptions,
 ) => {
+    const worker = getTransformWorker(config.uniwind.isExpoProject)
     const isCss = options.type !== 'asset' && path.join(process.cwd(), config.uniwind.cssEntryFile) === path.join(projectRoot, filePath)
 
     if (filePath.endsWith('/components/web/metro-injected.js')) {

--- a/packages/uniwind/src/bundler/config.ts
+++ b/packages/uniwind/src/bundler/config.ts
@@ -83,8 +83,11 @@ export class UniwindBundlerConfig {
         return `[${this.themes.map((theme) => `'${theme}'`).join(', ')}]`
     }
 
-    toMetroConfig() {
-        return this.config
+    toMetroConfig(isExpoProject: boolean): UniwindMetroConfig {
+        return {
+            ...this.config,
+            isExpoProject,
+        }
     }
 
     async generateArtifacts(cssArtifactPath: string) {

--- a/packages/uniwind/src/bundler/types.ts
+++ b/packages/uniwind/src/bundler/types.ts
@@ -11,5 +11,6 @@ export type Polyfills = {
 export type UniwindMetroConfig = UniwindConfig & {
     polyfills?: Polyfills
     debug?: boolean
+    isExpoProject?: boolean
     isTV?: boolean
 }


### PR DESCRIPTION
This fixes monorepos that contain both an Expo app and a plain React Native app, where the plain RN app can accidentally resolve Expo's transform worker and fail to build.

Repro app: https://github.com/sync/uniwee

On main, which has this patch applied, `pnpm build:ios` succeeds. On the `without-patch` branch, `pnpm build:ios` fails with:

Unexpected module with full source map found: node_modules/metro-runtime/src/polyfills/require.js

```
error Unexpected module with full source map found: /Users/anthonymittaz/Projects/expo/uniwee/node_modules/metro-runtime/src/polyfills/require.js.
Error: Unexpected module with full source map found: /Users/anthonymittaz/Projects/expo/uniwee/node_modules/metro-runtime/src/polyfills/require.js
    at processNextModule (/Users/anthonymittaz/Projects/expo/uniwee/node_modules/metro-source-map/src/source-map.js:78:13)
    at workLoop (/Users/anthonymittaz/Projects/expo/uniwee/node_modules/metro-source-map/src/source-map.js:88:22)
    at fromRawMappingsImpl (/Users/anthonymittaz/Projects/expo/uniwee/node_modules/metro-source-map/src/source-map.js:103:3)
    at /Users/anthonymittaz/Projects/expo/uniwee/node_modules/metro-source-map/src/source-map.js:122:5
    at new Promise (<anonymous>)
    at fromRawMappingsNonBlocking (/Users/anthonymittaz/Projects/expo/uniwee/node_modules/metro-source-map/src/source-map.js:121:10)
    at sourceMapGeneratorNonBlocking (/Users/anthonymittaz/Projects/expo/uniwee/node_modules/metro/src/DeltaBundler/Serializers/sourceMapGenerator.js:75:57)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async sourceMapStringNonBlocking (/Users/anthonymittaz/Projects/expo/uniwee/node_modules/metro/src/DeltaBundler/Serializers/sourceMapString.js:18:21)
    at async Server._serializeGraph (/Users/anthonymittaz/Projects/expo/uniwee/node_modules/metro/src/Server.js:216:19)
 ELIFECYCLE  Command failed with exit code 1.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Metro configuration handling to better detect Expo-based setups and apply the appropriate transformer settings.
  * Added an optional `isExpoProject` flag to Metro bundling configuration to enable Expo-aware behavior.
* **Bug Fixes**
  * Updated transformer worker selection to be resolved lazily and cached, ensuring the correct worker is used consistently for both JS and CSS transform flows.
* **Documentation**
  * Refined Metro integration notes to clarify how Expo transformer worker selection is determined and cached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->