### PR TITLE
fix: vite8 not prebundling react native web

### DIFF
--- a/packages/uniwind/src/bundler/adapters/vite/vite.ts
+++ b/packages/uniwind/src/bundler/adapters/vite/vite.ts
@@ -45,6 +45,7 @@ const resolveOrderedCSSStyleSheet = (source: string, importer: string | undefine
 }
 
 const vite8OptimizeDeps = {
+    include: ['react-native-web'],
     exclude: ['uniwind', 'react-native'],
     rolldownOptions: {
         plugins: [{


### PR DESCRIPTION
#595 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vite 8 dependency optimization by explicitly including React Native Web, helping ensure more reliable builds and development startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->