### PR TITLE
fix: adopt applied html theme

### DIFF
--- a/packages/uniwind/src/core/config/config.ts
+++ b/packages/uniwind/src/core/config/config.ts
@@ -16,6 +16,17 @@ class UniwindConfigBuilder extends UniwindConfigBuilderBase {
 
     constructor() {
         super()
+
+        if (typeof document === 'undefined') {
+            return
+        }
+
+        // Adopt the theme already applied to <html>, e.g. by an SSR anti-flicker script
+        const rootClasses = document.documentElement.classList
+        const rootTheme = this.themes.find((theme) => rootClasses.contains(theme))
+        if (rootTheme) {
+            this.setTheme(rootTheme)
+        }
     }
 
     updateCSSVariables(theme: ThemeName, variables: CSSVariables) {

--- a/packages/uniwind/tests/web/core/config.test.ts
+++ b/packages/uniwind/tests/web/core/config.test.ts
@@ -62,3 +62,37 @@ describe('Uniwind web config', () => {
         expect(getRule('.premium')?.style.getPropertyValue('--color-background')).toBe('#abcdef')
     })
 })
+
+describe('Uniwind web config initial theme', () => {
+    // The theme is adopted in the constructor, so the module has to be loaded
+    // after <html> already carries the class
+    const loadUniwind = (rootClassName: string) => {
+        document.documentElement.className = rootClassName
+
+        let instance: typeof Uniwind | undefined
+
+        jest.isolateModules(() => {
+            instance = (require('../../../src/core/config/config') as { Uniwind: typeof Uniwind }).Uniwind
+        })
+
+        return instance as typeof Uniwind
+    }
+
+    afterEach(() => {
+        document.documentElement.className = ''
+    })
+
+    test('adopts the theme already applied to <html>', () => {
+        const instance = loadUniwind('dark')
+
+        expect(instance.currentTheme).toBe('dark')
+        expect(instance.hasAdaptiveThemes).toBe(false)
+    })
+
+    test('keeps adaptive themes when <html> has no registered theme class', () => {
+        const instance = loadUniwind('no-theme-here')
+
+        expect(instance.currentTheme).toBe('light')
+        expect(instance.hasAdaptiveThemes).toBe(true)
+    })
+})


### PR DESCRIPTION
- #597
- Also tested manually in my project by patching node_modules
- Made with the help of Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Web themes now initialize correctly from an existing theme class on the page.
  * Helps prevent theme flicker during server-rendered page loads.
  * Preserves adaptive theme behavior when no recognized theme is present.

* **Tests**
  * Added coverage for initial dark-theme detection and adaptive-theme fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->