### PR TITLE
fix: handle multiline classes

### DIFF
--- a/packages/uniwind/src/core/native/store.ts
+++ b/packages/uniwind/src/core/native/store.ts
@@ -108,8 +108,11 @@ class UniwindStoreBuilder {
         let dependencySum = 0
         const bestBreakpoints = new Map<string, Style>()
         const isScopedTheme = uniwindContext.scopedTheme !== null
+        const classNameTokens = classNames.includes('\n')
+            ? classNames.split(/\s+/).filter(Boolean)
+            : classNames.split(' ')
 
-        for (const className of classNames.split(' ')) {
+        for (const className of classNameTokens) {
             if (!(className in this.stylesheet)) {
                 continue
             }

--- a/packages/uniwind/tests/native/styles-parsing/multiline.test.tsx
+++ b/packages/uniwind/tests/native/styles-parsing/multiline.test.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import View from '../../../src/components/native/View'
+import { TW_RED_500 } from '../../consts'
+import { renderUniwind } from '../utils'
+
+describe('Multiline', () => {
+    test('Multiline classes are handled', () => {
+        const { getStylesFromId } = renderUniwind(
+            <View
+                className={`bg-red-500
+                             border-2`}
+                testID="multiline"
+            />,
+        )
+
+        const multilineStyles = getStylesFromId('multiline')
+        expect(multilineStyles.backgroundColor).toBe(TW_RED_500)
+        expect(multilineStyles.borderWidth).toBe(2)
+    })
+})


### PR DESCRIPTION
#608 
Adds only around ~2-3ms in [our benchmarks](https://github.com/uni-stack/uniwind-benchmarks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed styling for native components when class names are separated by newlines or other whitespace.
  * Multiple utility classes now parse and apply together as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->