### PR TITLE
fix: withUniwind remove className props on web after converting them

### DIFF
--- a/packages/uniwind/src/hoc/withUniwind.tsx
+++ b/packages/uniwind/src/hoc/withUniwind.tsx
@@ -20,8 +20,9 @@ export const withUniwind: WithUniwind = <
     ? withManualUniwind(Component, options)
     : withAutoUniwind(Component)
 
-const withAutoUniwind = (Component: Component<AnyObject>) => (props: AnyObject) => {
+const withAutoUniwind = (Component: Component<AnyObject>) => (originalProps: AnyObject) => {
     const uniwindContext = useUniwindContext()
+    const props = { ...originalProps }
 
     const { classNames, generatedProps } = Object.entries(props).reduce((acc, [propName, propValue]) => {
         if (isColorClassProperty(propName)) {
@@ -45,6 +46,7 @@ const withAutoUniwind = (Component: Component<AnyObject>) => (props: AnyObject) 
                 ? formatColor(color)
                 : undefined
             acc.classNames += `${className} `
+            delete props[propName]
 
             return acc
         }
@@ -54,6 +56,7 @@ const withAutoUniwind = (Component: Component<AnyObject>) => (props: AnyObject) 
 
             acc.generatedProps[styleProp] ??= []
             acc.generatedProps[styleProp][0] = { $$css: true, tailwind: propValue }
+            delete props[propName]
 
             return acc
         }
@@ -61,6 +64,7 @@ const withAutoUniwind = (Component: Component<AnyObject>) => (props: AnyObject) 
         if (isStyleProperty(propName)) {
             acc.generatedProps[propName] ??= []
             acc.generatedProps[propName][1] = propValue
+            delete props[propName]
 
             return acc
         }
@@ -85,11 +89,13 @@ const withAutoUniwind = (Component: Component<AnyObject>) => (props: AnyObject) 
     )
 }
 
-const withManualUniwind = (Component: Component<AnyObject>, options: Record<PropertyKey, OptionMapping>) => (props: AnyObject) => {
+const withManualUniwind = (Component: Component<AnyObject>, options: Record<PropertyKey, OptionMapping>) => (originalProps: AnyObject) => {
     const uniwindContext = useUniwindContext()
+    const props = { ...originalProps }
 
     const { generatedProps, classNames } = Object.entries(options).reduce((acc, [propName, option]) => {
         const className = props[option.fromClassName]
+        delete props[option.fromClassName]
 
         if (className === undefined) {
             return acc

--- a/packages/uniwind/src/hoc/withUniwind.tsx
+++ b/packages/uniwind/src/hoc/withUniwind.tsx
@@ -28,6 +28,8 @@ const withAutoUniwind = (Component: Component<AnyObject>) => (originalProps: Any
         if (isColorClassProperty(propName)) {
             const colorProp = classToColor(propName)
 
+            delete props[propName]
+
             if (props[colorProp] !== undefined) {
                 return acc
             }
@@ -46,7 +48,6 @@ const withAutoUniwind = (Component: Component<AnyObject>) => (originalProps: Any
                 ? formatColor(color)
                 : undefined
             acc.classNames += `${className} `
-            delete props[propName]
 
             return acc
         }
@@ -94,7 +95,8 @@ const withManualUniwind = (Component: Component<AnyObject>, options: Record<Prop
     const props = { ...originalProps }
 
     const { generatedProps, classNames } = Object.entries(options).reduce((acc, [propName, option]) => {
-        const className = props[option.fromClassName]
+        // Read from original props because we're going to delete the prop from cloned props later
+        const className = originalProps[option.fromClassName]
         delete props[option.fromClassName]
 
         if (className === undefined) {

--- a/packages/uniwind/tests/web/hoc/withUniwind.test.tsx
+++ b/packages/uniwind/tests/web/hoc/withUniwind.test.tsx
@@ -85,6 +85,7 @@ describe('withUniwind', () => {
 
         expect(receivedProps).toHaveProperty('color')
         expect(receivedProps.color).toBe(TW_BLUE_500)
+        expect(receivedProps).not.toHaveProperty('colorClassName')
     })
 
     test('[manual] Should map testClassName to style', () => {
@@ -149,6 +150,7 @@ describe('withUniwind', () => {
 
         expect(receivedProps).toHaveProperty('color')
         expect(receivedProps.color).toBe(TW_BLUE_500)
+        expect(receivedProps).not.toHaveProperty('colorClassName')
     })
 
     test('[manual] Should add both inline style and className', () => {

--- a/packages/uniwind/tests/web/hoc/withUniwind.test.tsx
+++ b/packages/uniwind/tests/web/hoc/withUniwind.test.tsx
@@ -87,17 +87,17 @@ describe('withUniwind', () => {
         expect(receivedProps.color).toBe(TW_BLUE_500)
     })
 
-    test('[manual] Should map className to style', () => {
+    test('[manual] Should map testClassName to style', () => {
         ComponentWithSpy.mockClear()
 
         const ManualWithUniwind = withUniwind(ComponentWithSpy, {
             style: {
-                fromClassName: 'className',
+                fromClassName: 'testClassName',
             },
         })
 
         const { getByTestId } = render(
-            <ManualWithUniwind className="bg-red-500" testID="test-component" />,
+            <ManualWithUniwind testClassName="bg-red-500" testID="test-component" />,
         )
 
         const component = getByTestId('test-component')
@@ -108,10 +108,10 @@ describe('withUniwind', () => {
         const receivedProps = ComponentWithSpy.mock.calls[0][0]
 
         expect(receivedProps.style).toEqual([{ $$css: true, tailwind: 'bg-red-500' }, undefined])
-        expect(receivedProps).not.toHaveProperty('className')
+        expect(receivedProps).not.toHaveProperty('testClassName')
     })
 
-    test('[manual] Should map colorClassName to color', () => {
+    test('[manual] Should map testClassName to color', () => {
         const mockGetWebStyles = webCore.getWebStyles as jest.MockedFunction<typeof webCore.getWebStyles>
 
         mockGetWebStyles.mockReturnValue({ fill: TW_RED_500 })
@@ -119,18 +119,18 @@ describe('withUniwind', () => {
 
         const ManualWithUniwind = withUniwind(ComponentWithSpy, {
             color: {
-                fromClassName: 'colorClassName',
+                fromClassName: 'testClassName',
                 styleProperty: 'fill',
             },
         })
 
-        render(<ManualWithUniwind colorClassName="fill-red-500" testID="test-component" />)
+        render(<ManualWithUniwind testClassName="fill-red-500" testID="test-component" />)
 
         const receivedProps = ComponentWithSpy.mock.calls[0][0]
 
         expect(receivedProps).toHaveProperty('color')
         expect(receivedProps.color).toBe(TW_RED_500)
-        expect(receivedProps).not.toHaveProperty('colorClassName')
+        expect(receivedProps).not.toHaveProperty('testClassName')
     })
 
     test('[manual] Should override colorClassName with inline color', () => {

--- a/packages/uniwind/tests/web/hoc/withUniwind.test.tsx
+++ b/packages/uniwind/tests/web/hoc/withUniwind.test.tsx
@@ -20,7 +20,9 @@ describe('withUniwind', () => {
     })
 
     test('[auto] Should map className to style', () => {
-        const AutoWithUniwind = withUniwind(Component)
+        ComponentWithSpy.mockClear()
+
+        const AutoWithUniwind = withUniwind(ComponentWithSpy)
 
         const { getByTestId } = render(
             <AutoWithUniwind className="bg-red-500" testID="test-component" />,
@@ -30,6 +32,11 @@ describe('withUniwind', () => {
 
         expect(component).toBeInTheDocument()
         expect(component).toHaveClass('bg-red-500')
+
+        const receivedProps = ComponentWithSpy.mock.calls[0][0]
+
+        expect(receivedProps.style).toEqual([{ $$css: true, tailwind: 'bg-red-500' }])
+        expect(receivedProps).not.toHaveProperty('className')
     })
 
     test('[auto] Should map colorClassName to color', () => {
@@ -43,7 +50,6 @@ describe('withUniwind', () => {
         render(<AutoWithUniwind colorClassName="accent-red-500" testID="test-component" />)
 
         expect(mockGetWebStyles).toHaveBeenCalledWith('accent-red-500', {
-            'colorClassName': 'accent-red-500',
             'testID': 'test-component',
         }, UNIWIND_CONTEXT_MOCK)
 
@@ -51,6 +57,7 @@ describe('withUniwind', () => {
 
         expect(receivedProps).toHaveProperty('color')
         expect(receivedProps.color).toBe(TW_RED_500)
+        expect(receivedProps).not.toHaveProperty('colorClassName')
     })
 
     test('[auto] Should add both inline style and className', () => {
@@ -80,24 +87,31 @@ describe('withUniwind', () => {
         expect(receivedProps.color).toBe(TW_BLUE_500)
     })
 
-    test('[manual] Should map testClassName to style', () => {
-        const ManualWithUniwind = withUniwind(Component, {
+    test('[manual] Should map className to style', () => {
+        ComponentWithSpy.mockClear()
+
+        const ManualWithUniwind = withUniwind(ComponentWithSpy, {
             style: {
-                fromClassName: 'testClassName',
+                fromClassName: 'className',
             },
         })
 
         const { getByTestId } = render(
-            <ManualWithUniwind testClassName="bg-red-500" testID="test-component" />,
+            <ManualWithUniwind className="bg-red-500" testID="test-component" />,
         )
 
         const component = getByTestId('test-component')
 
         expect(component).toBeInTheDocument()
         expect(component).toHaveClass('bg-red-500')
+
+        const receivedProps = ComponentWithSpy.mock.calls[0][0]
+
+        expect(receivedProps.style).toEqual([{ $$css: true, tailwind: 'bg-red-500' }, undefined])
+        expect(receivedProps).not.toHaveProperty('className')
     })
 
-    test('[manual] Should map testClassName to color', () => {
+    test('[manual] Should map colorClassName to color', () => {
         const mockGetWebStyles = webCore.getWebStyles as jest.MockedFunction<typeof webCore.getWebStyles>
 
         mockGetWebStyles.mockReturnValue({ fill: TW_RED_500 })
@@ -105,17 +119,18 @@ describe('withUniwind', () => {
 
         const ManualWithUniwind = withUniwind(ComponentWithSpy, {
             color: {
-                fromClassName: 'testClassName',
+                fromClassName: 'colorClassName',
                 styleProperty: 'fill',
             },
         })
 
-        render(<ManualWithUniwind testClassName="fill-red-500" testID="test-component" />)
+        render(<ManualWithUniwind colorClassName="fill-red-500" testID="test-component" />)
 
         const receivedProps = ComponentWithSpy.mock.calls[0][0]
 
         expect(receivedProps).toHaveProperty('color')
         expect(receivedProps.color).toBe(TW_RED_500)
+        expect(receivedProps).not.toHaveProperty('colorClassName')
     })
 
     test('[manual] Should override colorClassName with inline color', () => {


### PR DESCRIPTION
#614 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented class-related and color-related input props from being forwarded to wrapped components during both automatic and manual unwinding.
  * Ensured generated style and color props are computed from the original values and applied as expected, without leaking intermediate props.
* **Tests**
  * Updated HOC tests to verify correct prop-forwarding behavior for auto and manual modes, including inline color override cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->