### PR TITLE
fix: align uniwind types with latest react native 0.87

### DIFF
--- a/packages/uniwind/types.d.ts
+++ b/packages/uniwind/types.d.ts
@@ -14,6 +14,8 @@ declare module 'react-native' {
     interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
         columnWrapperClassName?: string
         contentContainerClassName?: string
+        ListFooterComponentClassName?: string
+        ListHeaderComponentClassName?: string
     }
 
     interface ImageBackgroundProps extends ImagePropsBase {
@@ -41,6 +43,8 @@ declare module 'react-native' {
 
     interface SectionListProps<ItemT> extends VirtualizedListProps<ItemT> {
         contentContainerClassName?: string
+        ListFooterComponentClassName?: string
+        ListHeaderComponentClassName?: string
     }
 
     interface SwitchProps {


### PR DESCRIPTION
RN 0.87 flipped which types are served by default, `"types"` moved from the legacy tree to the Strict API tree (`react-native-strict-api` opt-in became `react-native-legacy-deep-imports` opt-out). 

In the strict tree`VirtualizedListWithoutRenderItemProps` interface doesn't exist anymore. It was restructured into a non-generic `VirtualizedListProps` type alias. The augmentation just created an orphan interface and the two props silently disappeared from `FlatList` / `SectionList`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional styling properties for FlatList and SectionList header and footer components.
  * Improved TypeScript support for applying custom class names to list headers and footers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->