### PR TITLE
chore: resolve dataSet to undefined when to data-set prop was provided

### DIFF
--- a/packages/uniwind/src/components/web/generateDataSet.ts
+++ b/packages/uniwind/src/components/web/generateDataSet.ts
@@ -1,10 +1,13 @@
 const toCamelCase = (str: string) => str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
 
 export const generateDataSet = (props: Record<PropertyKey, any>) => {
-    const dataSet: DataSet = props.dataSet !== undefined ? { ...props.dataSet } : {}
+    let dataSet = props.dataSet !== undefined
+        ? { ...props.dataSet } as DataSet
+        : undefined
 
     Object.entries(props).forEach(([key, value]) => {
         if (key.startsWith('data-')) {
+            dataSet ??= {}
             // Remove data- prefix
             dataSet[toCamelCase(key.slice(5))] = value
         }

--- a/packages/uniwind/src/core/web/getWebStyles.ts
+++ b/packages/uniwind/src/core/web/getWebStyles.ts
@@ -103,19 +103,23 @@ export const getWebStyles = (
 
         const dataSet = generateDataSet(componentProps ?? {})
 
-        Object.entries(dataSet).forEach(([key, value]) => {
-            if (value === false || value === undefined) {
-                return
-            }
+        if (dataSet) {
+            Object.entries(dataSet).forEach(([key, value]) => {
+                if (value === false || value === undefined) {
+                    return
+                }
 
-            dummy.dataset[key] = String(value)
-        })
+                dummy.dataset[key] = String(value)
+            })
+        }
 
         const computedStyles = getActiveStylesForClass(className)
 
-        Object.keys(dataSet).forEach(key => {
-            delete dummy.dataset[key]
-        })
+        if (dataSet) {
+            Object.keys(dataSet).forEach(key => {
+                delete dummy.dataset[key]
+            })
+        }
 
         return Object.fromEntries(
             Object.entries(computedStyles)

--- a/packages/uniwind/tests/web/components/generateDataSet.test.ts
+++ b/packages/uniwind/tests/web/components/generateDataSet.test.ts
@@ -1,0 +1,13 @@
+import { generateDataSet } from '../../../src/components/web/generateDataSet'
+
+describe('generateDataSet', () => {
+    test('returns undefined when no dataSet or data attributes are provided', () => {
+        expect(generateDataSet({})).toBeUndefined()
+    })
+
+    test('creates a dataSet from data attributes', () => {
+        expect(generateDataSet({ 'data-test-value': 'test' })).toEqual({
+            testValue: 'test',
+        })
+    })
+})


### PR DESCRIPTION
#625 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of elements without `data-*` attributes.
  * Prevented unnecessary dataset operations when no data is provided.
  * Preserved and correctly converted existing `data-*` attributes.

* **Tests**
  * Added coverage for empty datasets and converted data attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->