### PR TITLE
chore: dont pass dataSet if none data-* were provided to withUniwind component

### DIFF
--- a/packages/uniwind/src/hoc/withUniwind.tsx
+++ b/packages/uniwind/src/hoc/withUniwind.tsx
@@ -81,11 +81,16 @@ const withAutoUniwind = (Component: Component<AnyObject>) => (originalProps: Any
         return dispose
     }, [classNames])
 
+    const dataSet = generateDataSet(props)
+
+    if (dataSet) {
+        generatedProps.dataSet = dataSet
+    }
+
     return (
         <Component
             {...props}
             {...generatedProps}
-            dataSet={generateDataSet(props)}
         />
     )
 }
@@ -133,11 +138,16 @@ const withManualUniwind = (Component: Component<AnyObject>, options: Record<Prop
         return dispose
     }, [classNames])
 
+    const dataSet = generateDataSet(props)
+
+    if (dataSet) {
+        generatedProps.dataSet = dataSet
+    }
+
     return (
         <Component
             {...props}
             {...generatedProps}
-            dataSet={generateDataSet(props)}
         />
     )
 }


### PR DESCRIPTION
#625 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset handling for components using Uniwind enhancements.
  * Prevented empty dataset properties from being added when no dataset is available.
  * Ensured datasets are prepared before components render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->