### PR TITLE
feat: support drop-shadow filter function

### DIFF
--- a/packages/uniwind/src/bundler/css-processor/functions.ts
+++ b/packages/uniwind/src/bundler/css-processor/functions.ts
@@ -136,7 +136,7 @@ export class Functions {
         }
 
         if (fn.name === 'drop-shadow') {
-            return undefined
+            return this.processDropShadow(fn)
         }
 
         this.logger.warn(`Unsupported function - ${fn.name}`)
@@ -208,6 +208,24 @@ export class Functions {
         const expression = typeof amount === 'string' && amount.startsWith('"') ? amount : `(${amount})`
 
         return `"${fn.name}(" + ${expression} + "${FILTER_UNITS[fn.name] ?? ''})"`
+    }
+
+    private processDropShadow(fn: FunctionType) {
+        const nonWhitespaceArgs = fn.arguments.filter(
+            arg => !(typeof arg === 'object' && 'type' in arg && arg.type === 'token' && arg.value.type === 'white-space'),
+        )
+
+        const parts = nonWhitespaceArgs.map(arg => {
+            const processed = this.Processor.CSS.processValue(arg)
+
+            return typeof processed === 'string' && processed.startsWith('"')
+                ? processed
+                : `(${processed})`
+        })
+
+        const expression = parts.join(' + " " + ')
+
+        return `"drop-shadow(" + ${expression} + ")"`
     }
 
     private processColorMix(fn: FunctionType) {

--- a/packages/uniwind/tests/native/styles-parsing/filters.test.tsx
+++ b/packages/uniwind/tests/native/styles-parsing/filters.test.tsx
@@ -90,4 +90,57 @@ describe('Filters', () => {
 
         expect(filterOf(getStylesFromId('combined'))).toBe('blur(12px) grayscale(1)')
     })
+
+    test('Drop shadow', () => {
+        const { getStylesFromId } = renderUniwind(
+            <React.Fragment>
+                <View
+                    className="drop-shadow-sm"
+                    testID="drop-shadow-sm"
+                />
+                <View
+                    className="drop-shadow-md"
+                    testID="drop-shadow-md"
+                />
+                <View
+                    className="drop-shadow-lg"
+                    testID="drop-shadow-lg"
+                />
+                <View
+                    className="drop-shadow-xl"
+                    testID="drop-shadow-xl"
+                />
+                <View
+                    className="drop-shadow-2xl"
+                    testID="drop-shadow-2xl"
+                />
+                <View
+                    className="drop-shadow-none"
+                    testID="drop-shadow-none"
+                />
+                <View
+                    className="drop-shadow-[0_10px_8px_rgba(0,0,0,0.5)]"
+                    testID="drop-shadow-arbitrary"
+                />
+                <View
+                    className="drop-shadow-md blur-md"
+                    testID="drop-shadow-combined"
+                />
+                <View
+                    className="drop-shadow-md drop-shadow-red-500"
+                    testID="drop-shadow-colored"
+                />
+            </React.Fragment>,
+        )
+
+        expect(filterOf(getStylesFromId('drop-shadow-sm'))).toBe('drop-shadow(0 1 2 #00000026)')
+        expect(filterOf(getStylesFromId('drop-shadow-md'))).toBe('drop-shadow(0 3 3 #0000001f)')
+        expect(filterOf(getStylesFromId('drop-shadow-lg'))).toBe('drop-shadow(0 4 4 #00000026)')
+        expect(filterOf(getStylesFromId('drop-shadow-xl'))).toBe('drop-shadow(0 9 7 #0000001a)')
+        expect(filterOf(getStylesFromId('drop-shadow-2xl'))).toBe('drop-shadow(0 25 25 #00000026)')
+        expect(filterOf(getStylesFromId('drop-shadow-none'))).toBe('')
+        expect(filterOf(getStylesFromId('drop-shadow-arbitrary'))).toBe('drop-shadow(0 10 8 #00000080)')
+        expect(filterOf(getStylesFromId('drop-shadow-combined'))).toBe('blur(12px) drop-shadow(0 3 3 #0000001f)')
+        expect(filterOf(getStylesFromId('drop-shadow-colored'))).toBe('drop-shadow(0 3 3 #fb2c36ff)')
+    })
 })


### PR DESCRIPTION
## Summary

Add support for `drop-shadow` filter utilities in React Native. Previously, the `drop-shadow` function in the CSS processor returned `undefined`, causing all `drop-shadow-*` classes to be silently ignored on native.

This PR adds a `processDropShadow` handler that compiles Tailwind CSS v4's `drop-shadow()` filter function into React Native compatible filter strings.

Discussion: https://github.com/uni-stack/uniwind/discussions/644

## Changes

### `packages/uniwind/src/bundler/css-processor/functions.ts`

- Route `drop-shadow` function calls to the new `processDropShadow` method instead of returning `undefined`.
- Add `processDropShadow` private method that:
  - Filters out `white-space` tokens from the LightningCSS AST to prevent double-spacing.
  - Maps each argument through `processValue` and wraps appropriately for JS template expression.
  - Produces output like `"drop-shadow(" + (0) + " " + (3) + " " + (3) + " " + "#0000001f" + ")"`.

### `packages/uniwind/tests/native/styles-parsing/filters.test.tsx`

- Add comprehensive `Drop shadow` test block with 9 assertions covering:
  - All preset sizes (`drop-shadow-sm`, `drop-shadow-md`, `drop-shadow-lg`, `drop-shadow-xl`, `drop-shadow-2xl`)
  - `drop-shadow-none`
  - Arbitrary values (`drop-shadow-[0_10px_8px_rgba(0,0,0,0.5)]`)
  - Combined filters (`drop-shadow-md blur-md`)
  - Color modifiers (`drop-shadow-md drop-shadow-red-500`)

## Supported Utilities

| Class                                      | Output                                    |
| ------------------------------------------ | ----------------------------------------- |
| `drop-shadow-sm`                           | `drop-shadow(0 1 2 #00000026)`            |
| `drop-shadow-md`                           | `drop-shadow(0 3 3 #0000001f)`            |
| `drop-shadow-lg`                           | `drop-shadow(0 4 4 #00000026)`            |
| `drop-shadow-xl`                           | `drop-shadow(0 9 7 #0000001a)`            |
| `drop-shadow-2xl`                          | `drop-shadow(0 25 25 #00000026)`          |
| `drop-shadow-none`                         | _(empty — no filter)_                     |
| `drop-shadow-[0_10px_8px_rgba(0,0,0,0.5)]` | `drop-shadow(0 10 8 #00000080)`           |
| `blur-md drop-shadow-md`                   | `blur(12px) drop-shadow(0 3 3 #0000001f)` |
| `drop-shadow-md drop-shadow-red-500`       | `drop-shadow(0 3 3 #fb2c36ff)`            |

## Verification

All CI-equivalent checks pass locally:

- ✅ `bun run build`
- ✅ `bun run check:typescript`
- ✅ `bun run check:typescript:test`
- ✅ `bun run lint`
- ✅ `bun run check:format`
- ✅ `bun run circular:check`
- ✅ `bun run test:native` (147 tests passed)
- ✅ `bun run test:web` (26 tests passed)
- ✅ `bun run test:types`
- ✅ `bun run test:e2e` (9 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed drop-shadow styles so they render correctly in React Native.
  * Preserved spacing, quoted values, custom shadow definitions, and color combinations.
  * Ensured drop-shadow utilities work alongside blur filters and support the “none” option.

* **Tests**
  * Added coverage for standard shadow sizes, custom values, blur combinations, colored shadows, and disabled shadows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->