### PR TITLE
fix: web lazy components not hot reloading css

### DIFF
--- a/packages/uniwind/src/bundler/adapters/metro/metro.ts
+++ b/packages/uniwind/src/bundler/adapters/metro/metro.ts
@@ -3,8 +3,8 @@ import type { UniwindConfig } from '@/bundler/types'
 import { Platform } from '@/common/consts'
 import type { MetroConfig } from 'metro-config'
 import type { CustomResolver } from 'metro-resolver'
-import { join } from 'node:path'
-import { cacheStore, patchMetroGraphToSupportUncachedModules } from './patches'
+import { join, resolve } from 'node:path'
+import { cacheStore, patchMetroGraphToIncludeCssInLazyGraphs, patchMetroGraphToSupportUncachedModules } from './patches'
 import { nativeResolver, webResolver } from './resolvers'
 
 const isUniwindRequest = (moduleName: string) => moduleName === 'uniwind' || moduleName.startsWith('uniwind/')
@@ -28,6 +28,7 @@ export const withUniwindConfig = <T extends MetroConfig>(
     const bundlerConfig = UniwindBundlerConfig.fromMetroConfig(uniwindConfig)
     const pinnedUniwindOrigin = join(config.projectRoot ?? process.cwd(), 'package.json')
 
+    patchMetroGraphToIncludeCssInLazyGraphs(resolve(process.cwd(), uniwindConfig.cssEntryFile))
     patchMetroGraphToSupportUncachedModules()
 
     return {

--- a/packages/uniwind/src/bundler/adapters/metro/patches.ts
+++ b/packages/uniwind/src/bundler/adapters/metro/patches.ts
@@ -24,6 +24,35 @@ interface TraverseDependencies {
     __patched?: boolean
 }
 
+interface InitialTraverseDependencies {
+    (options: GraphOptions<any>): Promise<GraphResult<any>>
+    __uniwindLazyCssEntryPatched?: boolean
+}
+
+export const patchMetroGraphToIncludeCssInLazyGraphs = (cssEntryPath: string) => {
+    const { Graph } = require('metro/private/DeltaBundler/Graph') as typeof MetroGraphModule
+
+    // oxlint-disable-next-line @typescript-eslint/unbound-method
+    const original_initialTraverseDependencies = Graph.prototype.initialTraverseDependencies as unknown as InitialTraverseDependencies
+
+    if (original_initialTraverseDependencies.__uniwindLazyCssEntryPatched) {
+        return
+    }
+
+    async function initialTraverseDependencies(this: Graph, options: GraphOptions<any>) {
+        if (options.lazy && options.transformOptions.dev) {
+            const entryPoints = this.entryPoints as Set<string>
+            entryPoints.add(cssEntryPath)
+        }
+
+        return original_initialTraverseDependencies.call(this, options)
+    }
+
+    // @ts-expect-error patch Graph initialTraverseDependencies method
+    Graph.prototype.initialTraverseDependencies = initialTraverseDependencies
+    initialTraverseDependencies.__uniwindLazyCssEntryPatched = true
+}
+
 export const patchMetroGraphToSupportUncachedModules = () => {
     const { Graph } = require('metro/private/DeltaBundler/Graph') as typeof MetroGraphModule
 


### PR DESCRIPTION
#642 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-mode loading so CSS is included reliably when using Metro’s lazy graph.
  * Prevented CSS-related styling issues caused by incomplete dependency graph traversal.
* **Compatibility**
  * Added safeguards to ensure the Metro integration can be applied repeatedly without duplicate changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->