### PR TITLE
fix: skip unchanged native stylesheet reinitialization

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,7 +119,7 @@ Metro integration:
 - Metro adds `css` as source extension and removes it from asset extensions.
 - Metro transformer handles the configured CSS entry file specially.
 - Metro transformer worker selection is lazy, cached per Expo/non-Expo config type, and follows Expo transformer paths or Expo-specific config markers.
-- Native platform CSS transforms into a JS module that calls `Uniwind.__reinit(...)`.
+- Native platform CSS transforms into a JS module that calls `Uniwind.__reinit(...)` with a fingerprint of the generated styles and themes. During development, the native runtime skips reinitialization when that fingerprint is unchanged.
 - Web platform CSS transforms into CSS plus web runtime setup.
 - Resolver swaps React Native component imports to Uniwind-aware implementations where needed.
 

--- a/packages/uniwind/src/bundler/adapters/metro/transformer.ts
+++ b/packages/uniwind/src/bundler/adapters/metro/transformer.ts
@@ -5,6 +5,7 @@ import { Platform } from '@/common/consts'
 import type * as ExpoMetroConfig from '@expo/metro-config'
 import type * as MetroTransformWorker from 'metro-transform-worker'
 import type { JsTransformerConfig, JsTransformOptions } from 'metro-transform-worker'
+import { createHash } from 'node:crypto'
 import path from 'path'
 
 const cssArtifactPath = path.resolve(__dirname, '../../uniwind.css')
@@ -69,13 +70,20 @@ export const transform = async (
     await bundlerConfig.generateArtifacts(cssArtifactPath)
     const virtualCode = await compileCSS(bundlerConfig)
     const isWeb = bundlerConfig.platform === Platform.Web
+    const nativeStylesFingerprint = isWeb
+        ? undefined
+        : createHash('sha256')
+            .update(virtualCode)
+            .update('\0')
+            .update(bundlerConfig.stringifiedThemes)
+            .digest('hex')
 
     data = Buffer.from(
         isWeb
             ? virtualCode
             : [
                 `const { Uniwind } = require('uniwind');`,
-                `Uniwind.__reinit(rt => ${virtualCode}, ${bundlerConfig.stringifiedThemes});`,
+                `Uniwind.__reinit(rt => ${virtualCode}, ${bundlerConfig.stringifiedThemes}, '${nativeStylesFingerprint}');`,
             ].join(''),
         'utf-8',
     )

--- a/packages/uniwind/src/core/config/config.native.ts
+++ b/packages/uniwind/src/core/config/config.native.ts
@@ -8,6 +8,8 @@ import type { CSSVariables, GenerateStyleSheetsCallback, ThemeName } from '../ty
 import { UniwindConfigBuilder as UniwindConfigBuilderBase } from './config.common'
 
 class UniwindConfigBuilder extends UniwindConfigBuilderBase {
+    private stylesFingerprint: string | undefined
+
     constructor() {
         super()
     }
@@ -35,9 +37,18 @@ class UniwindConfigBuilder extends UniwindConfigBuilderBase {
         UniwindListener.notify([StyleDependency.Insets])
     }
 
-    protected __reinit(generateStyleSheetCallback: GenerateStyleSheetsCallback, themes: Array<string>) {
+    protected __reinit(
+        generateStyleSheetCallback: GenerateStyleSheetsCallback,
+        themes: Array<string>,
+        stylesFingerprint?: string,
+    ) {
+        if (__DEV__ && stylesFingerprint !== undefined && stylesFingerprint === this.stylesFingerprint) {
+            return
+        }
+
         super.__reinit(generateStyleSheetCallback, themes)
         UniwindStore.reinit(generateStyleSheetCallback, themes)
+        this.stylesFingerprint = stylesFingerprint
     }
 
     protected onThemeChange() {

--- a/packages/uniwind/tests/native/core/config.test.ts
+++ b/packages/uniwind/tests/native/core/config.test.ts
@@ -1,0 +1,52 @@
+import { Uniwind } from '../../../src/core/config/config.native'
+import { UniwindStore } from '../../../src/core/native'
+import type { GenerateStyleSheetsCallback } from '../../../src/core/types'
+
+type UniwindForTest = typeof Uniwind & {
+    __reinit: (initialize: GenerateStyleSheetsCallback, themes: Array<string>, fingerprint?: string) => void
+}
+
+const uniwind = Uniwind as UniwindForTest
+const generateStyles = () => ({ scopedVars: {}, stylesheet: {}, vars: {} })
+
+describe('Uniwind native config', () => {
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    test('skips reinitialization when generated styles have not changed', () => {
+        const reinit = jest.spyOn(UniwindStore, 'reinit')
+        const initialize = jest.fn(generateStyles)
+
+        uniwind.__reinit(initialize, ['light', 'dark'], 'unchanged-styles')
+        uniwind.__reinit(initialize, ['light', 'dark'], 'unchanged-styles')
+
+        expect(reinit).toHaveBeenCalledTimes(1)
+    })
+
+    test('reinitializes when generated styles change', () => {
+        const reinit = jest.spyOn(UniwindStore, 'reinit')
+        const initialize = jest.fn(generateStyles)
+
+        uniwind.__reinit(initialize, ['light', 'dark'], 'styles-before')
+        uniwind.__reinit(initialize, ['light', 'dark'], 'styles-after')
+
+        expect(reinit).toHaveBeenCalledTimes(2)
+    })
+
+    test('retries the same generated styles after initialization fails', () => {
+        const initialize = jest.fn(generateStyles)
+        const reinit = jest
+            .spyOn(UniwindStore, 'reinit')
+            .mockImplementationOnce(() => {
+                throw new Error('initialization failed')
+            })
+
+        expect(() => uniwind.__reinit(initialize, ['light', 'dark'], 'retry-styles')).toThrow(
+            'initialization failed',
+        )
+        uniwind.__reinit(initialize, ['light', 'dark'], 'retry-styles')
+
+        expect(reinit).toHaveBeenCalledTimes(2)
+    })
+})


### PR DESCRIPTION
> [!NOTE]
> The following is agent reported but I got approval from Hubert to file this so hope you don't mind: 
> <img width="1768" height="892" alt="CleanShot 2026-08-31 at 09 54 05@2x" src="https://github.com/user-attachments/assets/660a8ac8-bcd9-4088-882f-e8100d222957" />

---

We found this while profiling slow Fast Refresh in T3 Code Mobile with Hermes CPU samples and React timing traces against a populated environment.

A comment-only edit to an **unmounted screen** caused Uniwind to reinitialize the native stylesheet, clear style caches, and call `notifyAll()`, even though the generated styles hadn't changed. That made unrelated mounted components do work. Instrumenting `__reinit` and temporarily bypassing it for that edit confirmed the source of the extra work.

This patch fingerprints the generated native stylesheet and theme list in the Metro transformer. In development, `__reinit` skips reinitialization when the fingerprint matches the last successful initialization.

CSS compilation and class discovery still run. Hashing the generated output matters because edits to component files can introduce new Tailwind classes without changing the CSS source.

For the comparison, we used the same patched build and toggled only the fingerprint guard. The control omitted the fingerprint argument; the treatment supplied it. Measurements cover the same two-second window around a comment-only edit.

| Metric | Before | After |
| --- | ---: | ---: |
| Home: active sampled JS time | 163.2 ms | 92.8 ms |
| Home: React timing entries | 636 | 270 |
| Large thread: active sampled JS time | 237.2 ms | 96.1 ms |
| Large thread: React timing entries | 879 | 287 |

That's approximately **43% less sampled JS work on Home and 59% less on the large thread**.

These were individual matched simulator runs using Expo 57.0.18, React Native 0.86.3, and Uniwind 1.7.0 on an iPhone 17 Pro simulator running iOS 26.5. They measure work around the edit, not end-to-end Fast Refresh latency.

We subsequently rebased and verified the patch on Uniwind 1.11.0:

- Three edits with unchanged generated styles each caused zero stylesheet rebuilds and zero global notifications.
- Adding and removing a Tailwind candidate each caused one rebuild and one notification.
- Fast Refresh preserved the JS runtime; native light/dark switching still worked.

Changed styles or theme lists still initialize normally. The fingerprint is stored only after initialization succeeds, allowing failed initialization to retry. Calls without a fingerprint, production initialization, and the web path retain their existing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved native development performance by skipping redundant style reinitialization when styles and themes are unchanged.
  * Native style updates still reinitialize correctly when changes are detected.

* **Bug Fixes**
  * Improved recovery after a failed style initialization so subsequent attempts can proceed normally.

* **Documentation**
  * Updated build and bundler documentation to describe native style fingerprinting and reinitialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->