### PR TITLE
ci: close pro issues on release with different message than oss

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,8 +115,14 @@ jobs:
           TAG="v$VERSION"
           RELEASE_URL="$(gh release view "$TAG" --json url --jq .url)"
 
-          gh issue list --state open --label "pending-release" --json number --jq '.[].number' | while read -r ISSUE; do
+          gh issue list --state open --label "pending-release" --json number,labels --jq '.[] | [.number, any(.labels[]; .name == "uniwind-pro")] | @tsv' | while read -r ISSUE IS_PRO; do
+            if [ "$IS_PRO" = "true" ]; then
+              MESSAGE="New release is published: https://docs.uniwind.dev/pro/changelog"
+            else
+              MESSAGE="New release $TAG is published: $RELEASE_URL"
+            fi
+
             gh issue edit "$ISSUE" --remove-label "pending-release" || echo "::warning::failed to remove label on #$ISSUE"
-            gh issue comment "$ISSUE" --body "New release $TAG is published: $RELEASE_URL" || echo "::warning::failed to comment on #$ISSUE"
+            gh issue comment "$ISSUE" --body "$MESSAGE" || echo "::warning::failed to comment on #$ISSUE"
             gh issue close "$ISSUE" || echo "::warning::failed to close #$ISSUE"
           done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release-related issue comments now link to the appropriate changelog for pro releases.
  * Standard release issues continue to reference the relevant release tag and GitHub release page.
  * Existing labeling, commenting, and issue-closing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->